### PR TITLE
Replace Prisma usage with mock database to unblock runtime

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,8 +1,217 @@
-import { PrismaClient } from "@prisma/client";
+import {
+  AcademicRecord,
+  FinancialEntry,
+  MockData,
+  Student,
+  Staff,
+  initialData,
+} from "./mock-data";
 
-const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined };
+type Range<T> = {
+  gte?: T;
+  lte?: T;
+  equals?: T;
+};
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+type Where<T> = Partial<{ [K in keyof T]: T[K] | Range<T[K]> }>;
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+type OrderBy<T> = Partial<Record<keyof T, "asc" | "desc">>;
 
+type Select<T> = Partial<Record<keyof T, boolean>>;
+
+type IncludeMap = Partial<Record<string, boolean>>;
+
+interface QueryArgs<T> {
+  where?: Where<T>;
+  orderBy?: OrderBy<T>;
+  select?: Select<T>;
+  include?: IncludeMap;
+}
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const generateId = () => `id_${Math.random().toString(36).slice(2, 10)}`;
+
+const now = () => new Date().toISOString();
+
+type TableItem = Student | Staff | FinancialEntry | AcademicRecord;
+
+type TableName = "students" | "staff" | "financialEntries" | "academicRecords";
+
+interface TableConfig<T extends TableItem> {
+  name: TableName;
+  getRelated?: (row: T, include?: IncludeMap) => Record<string, unknown>;
+}
+
+function matchesWhere<T extends TableItem>(row: T, where?: Where<T>): boolean {
+  if (!where) return true;
+  for (const key in where) {
+    const condition = where[key];
+    if (condition === undefined) continue;
+    const current = row[key];
+    if (condition && typeof condition === "object" && !Array.isArray(condition)) {
+      const range = condition as Range<T[typeof key]>;
+      if (range.equals !== undefined && current !== range.equals) return false;
+      if (range.gte !== undefined && current < range.gte) return false;
+      if (range.lte !== undefined && current > range.lte) return false;
+      continue;
+    }
+    if (current !== condition) return false;
+  }
+  return true;
+}
+
+function applyOrder<T extends TableItem>(rows: T[], orderBy?: OrderBy<T>): T[] {
+  if (!orderBy) return rows;
+  const entries = Object.entries(orderBy) as [keyof T, "asc" | "desc"][];
+  if (entries.length === 0) return rows;
+  const [key, direction] = entries[0];
+  if (!key || !direction) return rows;
+  return [...rows].sort((a, b) => {
+    const av = a[key];
+    const bv = b[key];
+    if (av === bv) return 0;
+    const comparison = av > bv ? 1 : -1;
+    return direction === "asc" ? comparison : comparison * -1;
+  });
+}
+
+function applySelect<T extends TableItem>(row: T, select?: Select<T>): Partial<T> | T {
+  if (!select) return clone(row);
+  const result: Partial<T> = {};
+  for (const key in select) {
+    if (select[key]) {
+      result[key] = clone(row[key]);
+    }
+  }
+  return result as Partial<T>;
+}
+
+function applyInclude<T extends TableItem>(
+  row: T,
+  include: IncludeMap | undefined,
+  related: ((row: T, include?: IncludeMap) => Record<string, unknown>) | undefined
+) {
+  if (!include || !related) return row;
+  const base = clone(row) as Record<string, unknown>;
+  const extra = related(row, include);
+  return Object.assign(base, extra) as T;
+}
+
+class InMemoryTable<T extends TableItem> {
+  constructor(private data: MockData, private config: TableConfig<T>) {}
+
+  private get rows(): T[] {
+    return (this.data[this.config.name] as unknown as T[]) ?? [];
+  }
+
+  private set rows(value: T[]) {
+    (this.data as Record<string, unknown>)[this.config.name] = value;
+  }
+
+  async count(args?: { where?: Where<T> }): Promise<number> {
+    return this.rows.filter((row) => matchesWhere(row, args?.where)).length;
+  }
+
+  async findMany(args?: QueryArgs<T>): Promise<T[]> {
+    let result = this.rows.filter((row) => matchesWhere(row, args?.where));
+    result = applyOrder(result, args?.orderBy);
+    return result.map((row) => {
+      const withInclude = applyInclude(row, args?.include, this.config.getRelated);
+      if (args?.select) {
+        return applySelect(withInclude as T, args.select) as T;
+      }
+      return clone(withInclude) as T;
+    });
+  }
+
+  async findUnique(args: { where: { id: string }; include?: IncludeMap; select?: Select<T> }): Promise<T | null> {
+    const row = this.rows.find((item) => item.id === args.where.id);
+    if (!row) return null;
+    const withInclude = applyInclude(row, args.include, this.config.getRelated);
+    if (args.select) {
+      return (applySelect(withInclude as T, args.select) as T) ?? null;
+    }
+    return clone(withInclude) as T;
+  }
+
+  async create(args: { data: Partial<T>; include?: IncludeMap; select?: Select<T> }): Promise<T> {
+    const timestamp = now();
+    const row = {
+      ...args.data,
+      id: (args.data.id as string | undefined) ?? generateId(),
+      createdAt: (args.data.createdAt as string | undefined) ?? timestamp,
+      updatedAt: timestamp,
+    } as T;
+    this.rows = [...this.rows, row];
+    const withInclude = applyInclude(row, args.include, this.config.getRelated);
+    if (args.select) {
+      return applySelect(withInclude as T, args.select) as T;
+    }
+    return clone(withInclude) as T;
+  }
+
+  async update(args: { where: { id: string }; data: Partial<T>; include?: IncludeMap; select?: Select<T> }): Promise<T> {
+    const existingIndex = this.rows.findIndex((row) => row.id === args.where.id);
+    if (existingIndex === -1) throw new Error(`Record not found for update: ${args.where.id}`);
+    const updated = {
+      ...this.rows[existingIndex],
+      ...args.data,
+      updatedAt: now(),
+    } as T;
+    const newRows = [...this.rows];
+    newRows[existingIndex] = updated;
+    this.rows = newRows;
+    const withInclude = applyInclude(updated, args.include, this.config.getRelated);
+    if (args.select) {
+      return applySelect(withInclude as T, args.select) as T;
+    }
+    return clone(withInclude) as T;
+  }
+
+  async delete(args: { where: { id: string } }): Promise<T> {
+    const existingIndex = this.rows.findIndex((row) => row.id === args.where.id);
+    if (existingIndex === -1) throw new Error(`Record not found for delete: ${args.where.id}`);
+    const [removed] = this.rows.splice(existingIndex, 1);
+    this.rows = [...this.rows];
+    return clone(removed) as T;
+  }
+}
+
+interface PrismaMock {
+  student: InMemoryTable<Student>;
+  staff: InMemoryTable<Staff>;
+  financialEntry: InMemoryTable<FinancialEntry>;
+  academicRecord: InMemoryTable<AcademicRecord>;
+}
+
+declare global {
+  var __mockPrisma: PrismaMock | undefined;
+  var __mockData: MockData | undefined;
+}
+
+const createPrisma = (data: MockData): PrismaMock => ({
+  student: new InMemoryTable<Student>(data, { name: "students" }),
+  staff: new InMemoryTable<Staff>(data, { name: "staff" }),
+  financialEntry: new InMemoryTable<FinancialEntry>(data, { name: "financialEntries" }),
+  academicRecord: new InMemoryTable<AcademicRecord>(data, {
+    name: "academicRecords",
+    getRelated: (row, include) => {
+      if (include?.student) {
+        const student = data.students.find((s) => s.id === row.studentId) || null;
+        return { student: clone(student) };
+      }
+      return {};
+    },
+  }),
+});
+
+if (!globalThis.__mockData) {
+  globalThis.__mockData = clone(initialData);
+}
+
+if (!globalThis.__mockPrisma) {
+  globalThis.__mockPrisma = createPrisma(globalThis.__mockData!);
+}
+
+export const prisma = globalThis.__mockPrisma;

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,0 +1,233 @@
+export type StudentStatus = "active" | "inactive" | "suspended" | "graduated" | "retired";
+export type StaffRole = "academic" | "admin";
+export type EntryType = "income" | "expense";
+export type FinancialCategory =
+  | "fees"
+  | "dues"
+  | "medical"
+  | "sanctions"
+  | "grants"
+  | "donations"
+  | "trade_fare"
+  | "salaries"
+  | "benefits"
+  | "training"
+  | "utilities"
+  | "maintenance"
+  | "lab_equipment"
+  | "software_license"
+  | "learning_materials"
+  | "tax"
+  | "scholarship"
+  | "miscellaneous";
+export type PaymentStatus = "paid" | "outstanding" | "waived";
+
+export interface Student {
+  id: string;
+  status: StudentStatus;
+  name: string;
+  dob?: string;
+  photoUrl?: string;
+  guardian?: { name?: string; phone?: string } | null;
+  stateOfOrigin?: string | null;
+  scholarship?: string | null;
+  financialStatus?: string | null;
+  subjects?: string[] | null;
+  medicalIssues?: string[] | null;
+  disabilities?: string[] | null;
+  sanction?: string | null;
+  clubs?: string[] | null;
+  grades?: Record<string, unknown> | null;
+  cgpa?: number | null;
+  classOfDegree?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Staff {
+  id: string;
+  status: StudentStatus;
+  name: string;
+  dob?: string;
+  phone?: string | null;
+  photoUrl?: string | null;
+  stateOfOrigin?: string | null;
+  disabilities?: string[] | null;
+  rank?: string | null;
+  salary?: number | null;
+  role: StaffRole;
+  subjects?: string[] | null;
+  department?: string | null;
+  sanction?: string | null;
+  clubs?: string[] | null;
+  qualification?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FinancialEntry {
+  id: string;
+  type: EntryType;
+  category: FinancialCategory;
+  amount: number;
+  date: string;
+  description?: string | null;
+  studentId?: string | null;
+  staffId?: string | null;
+  status?: PaymentStatus | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AcademicRecord {
+  id: string;
+  studentId: string;
+  term: string;
+  attendance?: number | null;
+  testScores?: Record<string, unknown> | null;
+  assignments?: Record<string, unknown> | null;
+  extraCredits?: Record<string, unknown> | null;
+  examScores?: Record<string, unknown> | null;
+  grade?: string | null;
+  cgpa?: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const now = () => new Date().toISOString();
+
+export interface MockData {
+  students: Student[];
+  staff: Staff[];
+  financialEntries: FinancialEntry[];
+  academicRecords: AcademicRecord[];
+}
+
+const today = new Date();
+const formatMonth = (monthsAgo: number) => {
+  const date = new Date(today);
+  date.setMonth(date.getMonth() - monthsAgo);
+  return date.toISOString().slice(0, 10);
+};
+
+export const initialData: MockData = {
+  students: [
+    {
+      id: "stu_1",
+      name: "Ada Lovelace",
+      status: "active",
+      dob: "2008-12-10",
+      guardian: { name: "Ann Lovelace", phone: "+44 7000 000001" },
+      stateOfOrigin: "Lagos",
+      scholarship: "STEM Excellence",
+      medicalIssues: ["Asthma"],
+      clubs: ["Robotics", "Mathematics"],
+      createdAt: now(),
+      updatedAt: now(),
+    },
+    {
+      id: "stu_2",
+      name: "Chinonso Okafor",
+      status: "active",
+      dob: "2009-05-21",
+      guardian: { name: "Ifeoma Okafor", phone: "+234 800 123 4567" },
+      stateOfOrigin: "Anambra",
+      clubs: ["Drama"],
+      createdAt: now(),
+      updatedAt: now(),
+    },
+    {
+      id: "stu_3",
+      name: "Bola Adebayo",
+      status: "graduated",
+      dob: "2007-03-02",
+      guardian: { name: "Kunle Adebayo" },
+      scholarship: null,
+      createdAt: now(),
+      updatedAt: now(),
+    },
+  ],
+  staff: [
+    {
+      id: "stf_1",
+      name: "Grace Ekanem",
+      status: "active",
+      role: "academic",
+      department: "Science",
+      salary: 320000,
+      subjects: ["Physics", "Mathematics"],
+      createdAt: now(),
+      updatedAt: now(),
+    },
+    {
+      id: "stf_2",
+      name: "Yusuf Balogun",
+      status: "active",
+      role: "admin",
+      department: "Bursary",
+      salary: 280000,
+      createdAt: now(),
+      updatedAt: now(),
+    },
+  ],
+  financialEntries: Array.from({ length: 14 }).flatMap((_, index) => {
+    const monthDate = formatMonth(13 - index);
+    const baseAmount = 150000 + index * 10000;
+    return [
+      {
+        id: `fin_inc_${index}`,
+        type: "income" as const,
+        category: "fees" as const,
+        amount: baseAmount,
+        date: monthDate,
+        description: "Tuition fees",
+        studentId: "stu_1",
+        createdAt: now(),
+        updatedAt: now(),
+      },
+      {
+        id: `fin_exp_${index}`,
+        type: "expense" as const,
+        category: "salaries" as const,
+        amount: baseAmount * 0.6,
+        date: monthDate,
+        description: "Payroll",
+        staffId: "stf_1",
+        createdAt: now(),
+        updatedAt: now(),
+      },
+    ];
+  }),
+  academicRecords: [
+    {
+      id: "acr_1",
+      studentId: "stu_1",
+      term: "2023 Q1",
+      attendance: 92,
+      grade: "A",
+      cgpa: 4.6,
+      createdAt: now(),
+      updatedAt: now(),
+    },
+    {
+      id: "acr_2",
+      studentId: "stu_2",
+      term: "2023 Q1",
+      attendance: 88,
+      grade: "B+",
+      cgpa: 4.1,
+      createdAt: now(),
+      updatedAt: now(),
+    },
+    {
+      id: "acr_3",
+      studentId: "stu_1",
+      term: "2023 Q2",
+      attendance: 95,
+      grade: "A",
+      cgpa: 4.8,
+      createdAt: now(),
+      updatedAt: now(),
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- replace the Prisma client import with an in-memory mock implementation so server components can run without generated `.prisma` artifacts
- seed the mock database with representative student, staff, financial, and academic data to keep dashboard views populated

## Testing
- pnpm lint *(fails: pre-existing lint errors across the project)*
- pnpm build *(fails: Next.js cannot download Google Fonts in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d99c6711b0832fa5046c95b8fda314