### PR TITLE
Polish marketing shell and enforce school login for suite modules

### DIFF
--- a/src/app/events/layout.tsx
+++ b/src/app/events/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import RequireAuth from "@/components/RequireAuth";
+
+export default function EventsLayout({ children }: { children: ReactNode }) {
+  return (
+    <RequireAuth
+      section="events and communications hub"
+      blurb="Authenticate to publish ceremonies, fixtures, notices, and family communications from a single hub."
+    >
+      {children}
+    </RequireAuth>
+  );
+}

--- a/src/app/financials/layout.tsx
+++ b/src/app/financials/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import RequireAuth from "@/components/RequireAuth";
+
+export default function FinancialsLayout({ children }: { children: ReactNode }) {
+  return (
+    <RequireAuth
+      section="financial command desk"
+      blurb="Sign in as the school to reconcile income, expenses, and cashflow with audit-ready exports."
+    >
+      {children}
+    </RequireAuth>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,28 +47,23 @@ export default function RootLayout({
                     <span className="text-xs uppercase tracking-[0.18em] text-white/60">School Suite</span>
                   </div>
                 </Link>
-                <div className="hidden lg:flex flex-1 items-center justify-center">
-                  <div className="relative w-full max-w-xl">
-                    <span className="pointer-events-none absolute inset-y-0 left-3 grid place-items-center text-white/40">
-                      <svg viewBox="0 0 20 20" aria-hidden className="h-4 w-4">
-                        <path
-                          d="M12.5 12.5 16 16"
-                          stroke="currentColor"
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                        <circle cx="8.5" cy="8.5" r="5.75" stroke="currentColor" strokeWidth="1.5" />
-                      </svg>
-                    </span>
-                    <input
-                      placeholder="Search the suite · Press ⌘K"
-                      className="w-full rounded-full border border-white/10 bg-white/10 py-2 pl-9 pr-4 text-sm text-white placeholder-white/50 transition focus:border-[var(--brand-500)] focus:bg-black/40 focus:outline-none"
-                    />
+                <div className="flex flex-1 items-center justify-center">
+                  <div className="hidden md:block">
+                    <Nav />
                   </div>
                 </div>
-                <div className="flex items-center gap-3">
-                  <Nav />
+                <div className="flex items-center gap-4">
+                  <div className="md:hidden">
+                    <Nav />
+                  </div>
+                  <div className="hidden text-right text-[11px] uppercase tracking-[0.3em] text-white/45 sm:block">
+                    <span className="block">Single sign-on</span>
+                    <span className="block text-white/35">Google Workspace</span>
+                  </div>
+                  <div className="hidden lg:flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.28em] text-white/55">
+                    <span className="h-2 w-2 rounded-full bg-[var(--brand)] shadow-[0_0_10px_rgba(217,4,41,0.8)]" aria-hidden />
+                    Schools only
+                  </div>
                   <UserMenu />
                 </div>
               </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,9 @@
-import Link from "next/link";
-import Image from "next/image";
 import Hero from "@/components/Hero";
-import Reveal from "@/components/Reveal";
 import QuickLinks from "@/components/QuickLinks";
 import Showcase from "@/components/Showcase";
 import DashboardOverview from "@/components/DashboardOverview";
 import CTA from "@/components/CTA";
+import DeliveryPlan from "@/components/DeliveryPlan";
 
 export default function Home() {
   return (
@@ -14,6 +12,7 @@ export default function Home() {
       <QuickLinks />
       <div className="mt-10 gradient-line animate" />
       <Showcase />
+      <DeliveryPlan />
       <div className="mt-10 gradient-line animate" />
       <DashboardOverview />
       <CTA />

--- a/src/app/performance/layout.tsx
+++ b/src/app/performance/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import RequireAuth from "@/components/RequireAuth";
+
+export default function PerformanceLayout({ children }: { children: ReactNode }) {
+  return (
+    <RequireAuth
+      section="performance analytics studio"
+      blurb="Authenticate with the school workspace to trend attendance, assessments, clubs, and interventions."
+    >
+      {children}
+    </RequireAuth>
+  );
+}

--- a/src/app/staff/layout.tsx
+++ b/src/app/staff/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import RequireAuth from "@/components/RequireAuth";
+
+export default function StaffLayout({ children }: { children: ReactNode }) {
+  return (
+    <RequireAuth
+      section="staff operations console"
+      blurb="Login with your school domain to manage contracts, payroll cadences, and leadership reviews."
+    >
+      {children}
+    </RequireAuth>
+  );
+}

--- a/src/app/students/layout.tsx
+++ b/src/app/students/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import RequireAuth from "@/components/RequireAuth";
+
+export default function StudentsLayout({ children }: { children: ReactNode }) {
+  return (
+    <RequireAuth
+      section="student intelligence workspace"
+      blurb="Authenticate as the school to review biodata, guardians, fees, and performance interventions across every learner."
+    >
+      {children}
+    </RequireAuth>
+  );
+}

--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -4,24 +4,26 @@ export default function CTA() {
   return (
     <section className="mt-12">
       <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-r from-[#1a0106] via-[#2a0008] to-[#060606] p-8 md:p-12 text-white shadow-[0_20px_60px_-30px_rgba(217,4,41,0.7)]">
-        <div className="max-w-2xl space-y-3">
-          <h2 className="font-display text-[clamp(1.6rem,2.6vw,2.2rem)] font-semibold">Deploy your suite with confidence</h2>
+        <div className="max-w-3xl space-y-4">
+          <p className="text-xs uppercase tracking-[0.32em] text-white/50">Ready when you are</p>
+          <h2 className="font-display text-[clamp(1.6rem,2.6vw,2.3rem)] font-semibold">White-glove rollout for your leadership team</h2>
           <p className="text-white/70">
-            Configure cohorts, synchronise staff, and reconcile finances in minutes. A single matte-black command centre keeps
-            your team fast, focused, and audit ready.
+            We pair the refined Brand‑Stone interface with onboarding workshops, configuration playbooks, and a command runway
+            for bursary, academics, and HR. Your administrators stay in control, your data stays compliant, and the experience
+            feels premium from day zero.
           </p>
-          <div className="flex flex-wrap gap-3 pt-2">
+          <div className="flex flex-wrap gap-3 pt-1">
             <Link
-              href="/students"
+              href="/auth/sign-in"
               className="rounded-full bg-[var(--brand)] px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-[var(--brand-500)]"
             >
-              Explore students workspace
+              Initiate school login
             </Link>
             <Link
-              href="/financials/report"
+              href="/events"
               className="rounded-full border border-white/20 px-5 py-2.5 text-sm font-semibold text-white/80 transition hover:border-white/40 hover:text-white"
             >
-              Review financial reports
+              Preview engagement tools
             </Link>
           </div>
         </div>

--- a/src/components/DeliveryPlan.tsx
+++ b/src/components/DeliveryPlan.tsx
@@ -1,0 +1,91 @@
+import Reveal from "@/components/Reveal";
+
+const foundations = [
+  {
+    title: "Operational workspaces ready",
+    detail: "Students, staff, performance, events, and finance modules ship with dashboards, inline updates, and exports.",
+  },
+  {
+    title: "Matte-black design system",
+    detail: "Consistent typography, glass surfaces, and card treatments keep the suite premium and cohesive across pages.",
+  },
+  {
+    title: "Google Workspace authentication",
+    detail: "Federated login keeps access aligned to the school domain while remaining deterministic for demos and QA.",
+  },
+];
+
+const roadmap = [
+  {
+    phase: "01 · Data onboarding",
+    focus: "Bulk import rosters, staff records, and historical finance files with validation scripts and sandbox reviews.",
+  },
+  {
+    phase: "02 · Controls & automations",
+    focus: "Layer approvals, reminders, and integrations for bursary, HR, and academic workflows on top of the suite.",
+  },
+  {
+    phase: "03 · Launch & adoption",
+    focus: "Coach administrators, publish knowledge base artefacts, and monitor usage dashboards post go-live.",
+  },
+];
+
+export default function DeliveryPlan() {
+  return (
+    <section id="delivery" className="mt-16">
+      <div className="grid gap-8 lg:grid-cols-[1fr_1.1fr]">
+        <Reveal>
+          <div className="rounded-3xl border border-white/10 bg-[#0b0b0b]/90 p-8 shadow-[0_28px_90px_-45px_rgba(217,4,41,0.55)]">
+            <p className="text-xs uppercase tracking-[0.32em] text-white/40">What is live today</p>
+            <h2 className="mt-3 font-display text-2xl font-semibold text-white">Foundation locked in</h2>
+            <p className="mt-3 text-sm text-white/70">
+              Brand‑Stone already ships as a unified school cockpit. These are the pillars currently hardened inside the demo.
+            </p>
+            <ul className="mt-6 space-y-4 text-sm text-white/75">
+              {foundations.map((item) => (
+                <li key={item.title} className="rounded-2xl border border-white/10 bg-black/30 p-4">
+                  <div className="flex items-start gap-3">
+                    <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--brand)]/80 text-[11px] font-semibold text-white">✓</span>
+                    <div>
+                      <p className="font-medium text-white">{item.title}</p>
+                      <p className="mt-1 text-white/60">{item.detail}</p>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Reveal>
+        <Reveal delay={80}>
+          <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-[#120205]/90 via-[#18050a]/85 to-[#050505]/90 p-8">
+            <p className="text-xs uppercase tracking-[0.32em] text-white/40">How we go further</p>
+            <h2 className="mt-3 font-display text-2xl font-semibold text-white">Next moves for a pristine rollout</h2>
+            <p className="mt-3 text-sm text-white/70">
+              A deliberate three-phase plan ensures the suite transitions from polished prototype to production operations with your school.
+            </p>
+            <ol className="mt-6 space-y-4">
+              {roadmap.map((item, index) => (
+                <li key={item.phase} className="group relative overflow-hidden rounded-2xl border border-white/10 bg-black/30 p-5 transition hover:border-white/20">
+                  <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-transparent opacity-0 transition duration-300 group-hover:opacity-100" aria-hidden />
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.28em] text-white/40">
+                      <span>{item.phase}</span>
+                      <span>Phase {index + 1}</span>
+                    </div>
+                    <p className="text-sm text-white/75 leading-relaxed">{item.focus}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+            <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-white/60">
+              <p className="font-semibold uppercase tracking-[0.32em] text-white/45">Support cadence</p>
+              <p className="mt-2 leading-relaxed">
+                Weekly steering sessions with school leadership, async status reports, and a shared issue board keep the programme crisp and accountable.
+              </p>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -38,15 +38,19 @@ export default function Hero() {
       <div className="absolute inset-0 bg-grid opacity-[0.04] z-0" />
 
       <div className="relative z-10 max-w-2xl space-y-6">
+        <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.28em] text-white/60">
+          <span className="h-2 w-2 rounded-full bg-[var(--brand)] shadow-[0_0_12px_rgba(217,4,41,0.8)]" aria-hidden />
+          Accredited school release
+        </div>
         <motion.h1
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: "easeOut" }}
           className="font-display text-4xl md:text-6xl font-semibold leading-[1.05] tracking-tight"
         >
-          Precision control for your
+          Precision control for the
           <br />
-          <span className="brand-text">entire school estate.</span>
+          <span className="brand-text">modern school estate.</span>
         </motion.h1>
 
         <motion.p
@@ -55,8 +59,8 @@ export default function Hero() {
           transition={{ delay: 0.1, duration: 0.6, ease: "easeOut" }}
           className="text-white/70 max-w-prose text-base"
         >
-          Every module — students, staff, events, finance, performance — lives inside one matte-black cockpit tuned for speed,
-          focus, and audit-ready accuracy.
+          Login once as the school, unlock every workspace — students, staff, events, finance, and performance — with a glassy
+          command centre tuned for audits, collaboration, and calm execution.
         </motion.p>
 
         <motion.div
@@ -66,18 +70,32 @@ export default function Hero() {
           className="flex flex-wrap gap-3"
         >
           <Link
-            href="/students"
-            className="px-5 py-2.5 rounded-full bg-[var(--brand)] text-white shadow-lg shadow-[rgba(217,4,41,0.35)] transition hover:bg-[var(--brand-500)]"
+            href="/auth/sign-in"
+            className="rounded-full bg-[var(--brand)] px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-[rgba(217,4,41,0.35)] transition hover:bg-[var(--brand-500)]"
           >
-            Launch student hub
+            School login · Google Workspace
           </Link>
           <Link
-            href="/auth/sign-in"
-            className="px-5 py-2.5 rounded-full border border-white/20 text-white/80 transition hover:border-white/40 hover:text-white"
+            href="#delivery"
+            className="rounded-full border border-white/20 px-5 py-2.5 text-sm font-semibold text-white/80 transition hover:border-white/40 hover:text-white"
           >
-            Sign in with Google
+            Review implementation plan
           </Link>
         </motion.div>
+
+        <motion.ul
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.3, duration: 0.6, ease: "easeOut" }}
+          className="grid gap-3 pt-4 text-sm text-white/70 sm:grid-cols-2"
+        >
+          {["Unified dashboards", "Role-based audit trails", "Finance-grade exports", "Parent and staff communications"].map((point) => (
+            <li key={point} className="flex items-center gap-2">
+              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-white/20 bg-white/10 text-[10px] font-semibold text-white">✓</span>
+              {point}
+            </li>
+          ))}
+        </motion.ul>
       </div>
 
       <div className="relative z-10 hidden md:block">

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,10 +1,11 @@
 export default function PageHeader({ title, subtitle }: { title: string; subtitle?: string }) {
   return (
-    <div className="rounded-xl bg-gradient-to-r from-[var(--brand)]/12 to-transparent border p-5">
-      <h1 className="font-display text-xl sm:text-2xl font-semibold">{title}</h1>
-      {subtitle ? (
-        <p className="text-sm text-white/70 mt-1 max-w-3xl">{subtitle}</p>
-      ) : null}
+    <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-[#0b0b0b]/90 p-6 sm:p-7">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-[var(--brand)]/20 via-transparent to-transparent opacity-80" aria-hidden />
+      <div className="relative space-y-2">
+        <h1 className="font-display text-xl sm:text-2xl font-semibold text-white">{title}</h1>
+        {subtitle ? <p className="max-w-3xl text-sm text-white/70 leading-relaxed">{subtitle}</p> : null}
+      </div>
     </div>
   );
 }

--- a/src/components/QuickLinks.tsx
+++ b/src/components/QuickLinks.tsx
@@ -1,32 +1,82 @@
 import Link from "next/link";
-import Image from "next/image";
+import type { JSX } from "react";
 import Reveal from "@/components/Reveal";
+import { EventsIcon, FinancialsIcon, PerformanceIcon, StaffIcon, StudentsIcon } from "@/components/icons";
 
-const links = [
-  { href: "/students", title: "Students", desc: "Biodata, academics, finances", icon: "/icons/student.svg" },
-  { href: "/staff", title: "Staff", desc: "Biodata, roles, salaries", icon: "/icons/staff.svg" },
-  { href: "/performance", title: "Performance", desc: "Attendance, tests, exams, CGPA", icon: "/icons/performance.svg" },
-  { href: "/events", title: "Events", desc: "Calendar and notices", icon: "/icons/events.svg" },
-  { href: "/financials", title: "Financials", desc: "Income and expenses", icon: "/icons/financials.svg" },
+type LinkConfig = {
+  href: string;
+  title: string;
+  desc: string;
+  icon: (props: { className?: string }) => JSX.Element;
+  accent: string;
+};
+
+const links: LinkConfig[] = [
+  {
+    href: "/students",
+    title: "Students",
+    desc: "Admissions, welfare, guardians, and fees in one cockpit",
+    icon: (props) => <StudentsIcon className={props.className} />,
+    accent: "from-[#3a0d12] via-[#4b0f16] to-[#140203]",
+  },
+  {
+    href: "/staff",
+    title: "Staff",
+    desc: "Contracts, career paths, reviews, and payroll cadences",
+    icon: (props) => <StaffIcon className={props.className} />,
+    accent: "from-[#231403] via-[#3c2409] to-[#0f0601]",
+  },
+  {
+    href: "/performance",
+    title: "Performance",
+    desc: "Assessments, attendance, clubs, and interventions",
+    icon: (props) => <PerformanceIcon className={props.className} />,
+    accent: "from-[#071523] via-[#0c2133] to-[#02060a]",
+  },
+  {
+    href: "/events",
+    title: "Events",
+    desc: "Ceremonies, fixtures, notices, and community moments",
+    icon: (props) => <EventsIcon className={props.className} />,
+    accent: "from-[#151032] via-[#1f1846] to-[#06030f]",
+  },
+  {
+    href: "/financials",
+    title: "Financials",
+    desc: "Revenue, expenses, cashflow, and audit-ready ledgers",
+    icon: (props) => <FinancialsIcon className={props.className} />,
+    accent: "from-[#03271b] via-[#06402b] to-[#010b07]",
+  },
 ];
 
 export default function QuickLinks() {
   return (
     <section className="relative z-10 mt-10">
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
         {links.map((c, i) => (
           <Reveal key={c.href} delay={i * 50}>
             <Link
               href={c.href}
-              className="card p-5 group focus:outline-none focus:ring-2 focus:ring-[var(--brand)] hover:elev-1 transition-shadow"
+              className="group relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border border-white/10 bg-[#0b0b0b] p-5 transition-all hover:-translate-y-0.5 hover:border-[var(--brand)]/60 hover:shadow-[0_24px_70px_-30px_rgba(217,4,41,0.55)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)]"
               aria-label={`${c.title}: ${c.desc}`}
             >
-              <div className="flex items-start gap-3">
-                <Image src={c.icon} alt="" width={24} height={24} className="mt-0.5" aria-hidden />
-                <div>
-                  <div className="font-medium text-white group-hover:text-[var(--brand)] transition-colors">{c.title}</div>
-                  <div className="text-sm text-white/70">{c.desc}</div>
+              <div className={`absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100`}>
+                <div className={`absolute inset-0 bg-gradient-to-br ${c.accent} opacity-70`} />
+              </div>
+              <div className="relative flex items-start gap-4">
+                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/5 backdrop-blur">
+                  {c.icon({ className: "h-10 w-10" })}
                 </div>
+                <div className="space-y-2">
+                  <div className="font-display text-lg font-semibold text-white transition-colors group-hover:text-[var(--brand-500)]">
+                    {c.title}
+                  </div>
+                  <div className="text-sm text-white/70 leading-relaxed">{c.desc}</div>
+                </div>
+              </div>
+              <div className="relative mt-6 flex items-center gap-2 text-xs uppercase tracking-[0.28em] text-white/40">
+                <span className="h-[1px] w-6 bg-white/20" aria-hidden />
+                Enter workspace
               </div>
             </Link>
           </Reveal>

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import type { ReactNode } from "react";
+import { useAuth } from "./AuthProvider";
+
+export default function RequireAuth({
+  children,
+  section,
+  blurb,
+}: {
+  children: ReactNode;
+  section: string;
+  blurb?: string;
+}) {
+  const { status, user, signInWithGoogle } = useAuth();
+  const loading = status === "initializing" || status === "authenticating";
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[320px] items-center justify-center">
+        <div className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/70">
+          <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/20 border-t-white" aria-hidden />
+          <span>Confirming school access…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-[#090909]/95 p-8 sm:p-10">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-[#2a0008]/40 via-transparent to-transparent" aria-hidden />
+        <div className="relative max-w-2xl space-y-5">
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.28em] text-white/55">
+            <span className="h-2 w-2 rounded-full bg-[var(--brand)] shadow-[0_0_10px_rgba(217,4,41,0.8)]" aria-hidden />
+            Restricted workspace
+          </div>
+          <h2 className="font-display text-[clamp(1.6rem,2.6vw,2.2rem)] font-semibold text-white">School login required</h2>
+          <p className="text-sm text-white/70">
+            {blurb ?? `Authenticate with your Google Workspace identity to open the ${section}.`}
+          </p>
+          <div className="flex flex-wrap gap-3 pt-1">
+            <button
+              type="button"
+              onClick={() => void signInWithGoogle()}
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--brand)] px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-[var(--brand-500)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-500)]"
+            >
+              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-white text-xs font-bold text-black">G</span>
+              Launch school login
+            </button>
+            <Link
+              href="/auth/sign-in"
+              className="inline-flex items-center gap-2 rounded-full border border-white/15 px-5 py-2.5 text-sm font-semibold text-white/80 transition hover:border-white/40 hover:text-white"
+            >
+              View access details
+            </Link>
+          </div>
+          <ul className="grid gap-2 text-xs text-white/50 sm:grid-cols-2">
+            {["Audit trail ready", "Role-based permissions", "Secure local storage", "Demo resets anytime"].map((item) => (
+              <li key={item} className="flex items-center gap-2">
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-white/20 text-[9px] text-white">✓</span>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -6 }}
+        transition={{ duration: 0.2, ease: "easeOut" }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/SignInCard.tsx
+++ b/src/components/SignInCard.tsx
@@ -23,10 +23,10 @@ export default function SignInCard() {
   return (
     <div className="card space-y-6 p-6 sm:p-8">
       <div className="space-y-2">
-        <h2 className="font-display text-2xl font-semibold text-white">Secure access with Google</h2>
+        <h2 className="font-display text-2xl font-semibold text-white">Secure school login</h2>
         <p className="text-sm text-white/70">
-          Connect with your Google Workspace identity to unlock students, staff, finance, and performance dashboards in one
-          streamlined hub.
+          Connect with your Google Workspace tenancy to unlock students, staff, finance, performance, and events dashboards in
+          one matte-black cockpit.
         </p>
       </div>
 
@@ -40,7 +40,7 @@ export default function SignInCard() {
           <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-white text-xs font-bold text-black">
             G
           </span>
-          {authenticating ? "Connecting to Google…" : "Sign in with Google"}
+          {authenticating ? "Connecting to Google…" : "Launch school login"}
         </button>
       ) : (
         <div className="space-y-4 rounded-lg border border-white/10 bg-black/40 p-5">

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -59,7 +59,7 @@ export default function UserMenu() {
         className="inline-flex items-center gap-2 rounded-full bg-white text-black px-3.5 py-1.5 text-sm font-medium shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40"
       >
         <GoogleIcon className="h-4 w-4" />
-        Sign in with Google
+        School login
       </button>
     );
   }
@@ -83,7 +83,7 @@ export default function UserMenu() {
           {initials}
         </span>
         <span className="leading-tight">
-          <span className="block text-xs text-white/60">Signed in</span>
+          <span className="block text-xs text-white/60">School access</span>
           <span className="block max-w-[10rem] truncate font-medium">{user.name}</span>
         </span>
         <svg

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,185 @@
+import type { SVGProps } from "react";
+
+export type IconProps = SVGProps<SVGSVGElement> & { className?: string };
+
+const gradientId = (id: string) => `suite-${id}`;
+
+export function StudentsIcon({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 32 32" aria-hidden className={className} {...props}>
+      <defs>
+        <linearGradient id={gradientId("students") } x1="4" y1="6" x2="28" y2="22" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#ff6b81" />
+          <stop offset="1" stopColor="#ff2d55" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M4 11.5 16 6l12 5.5-12 5.5-12-5.5Z"
+        fill="none"
+        stroke={`url(#${gradientId("students")})`}
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M7 14.75v4.4c0 2.2 4 4.85 9 4.85s9-2.65 9-4.85v-4.4"
+        fill="none"
+        stroke="#f5f5f5"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity="0.8"
+      />
+    </svg>
+  );
+}
+
+export function StaffIcon({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 32 32" aria-hidden className={className} {...props}>
+      <defs>
+        <linearGradient id={gradientId("staff") } x1="6" y1="8" x2="26" y2="26" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#ffd166" />
+          <stop offset="1" stopColor="#ff922b" />
+        </linearGradient>
+      </defs>
+      <circle
+        cx="16"
+        cy="11"
+        r="5"
+        fill="none"
+        stroke={`url(#${gradientId("staff")})`}
+        strokeWidth="1.8"
+      />
+      <path
+        d="M6.5 26c1-4.8 4.9-8 9.5-8s8.5 3.2 9.5 8"
+        fill="none"
+        stroke="#f8f9fa"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        opacity="0.85"
+      />
+      <path
+        d="M11.2 18.4C12.4 17 14.1 16 16 16s3.6 1 4.8 2.4"
+        fill="none"
+        stroke="#f8f9fa"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        opacity="0.6"
+      />
+    </svg>
+  );
+}
+
+export function PerformanceIcon({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 32 32" aria-hidden className={className} {...props}>
+      <defs>
+        <linearGradient id={gradientId("performance") } x1="6" y1="24" x2="26" y2="8" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#4dabf7" />
+          <stop offset="1" stopColor="#1971c2" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M8 24V16m6 8V10m6 14v-7m6 7V8"
+        fill="none"
+        stroke={`url(#${gradientId("performance")})`}
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <polyline
+        points="8 16 14 10 20 17 26 8"
+        fill="none"
+        stroke="#f8f9fa"
+        strokeOpacity="0.7"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function EventsIcon({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 32 32" aria-hidden className={className} {...props}>
+      <defs>
+        <linearGradient id={gradientId("events") } x1="6" y1="8" x2="26" y2="26" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#a5b4fc" />
+          <stop offset="1" stopColor="#6366f1" />
+        </linearGradient>
+      </defs>
+      <rect
+        x="6"
+        y="8"
+        width="20"
+        height="18"
+        rx="4"
+        fill="none"
+        stroke={`url(#${gradientId("events")})`}
+        strokeWidth="1.8"
+      />
+      <path
+        d="M6 12h20"
+        stroke="#f8f9fa"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        opacity="0.75"
+      />
+      <path
+        d="M12 6v4m8-4v4"
+        stroke="#f8f9fa"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        opacity="0.75"
+      />
+      <rect x="11" y="16" width="4" height="4" rx="1" fill="#f8f9fa" opacity="0.8" />
+      <rect x="17" y="18" width="4" height="4" rx="1" fill="#f8f9fa" opacity="0.5" />
+    </svg>
+  );
+}
+
+export function FinancialsIcon({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 32 32" aria-hidden className={className} {...props}>
+      <defs>
+        <linearGradient id={gradientId("financials") } x1="8" y1="6" x2="26" y2="26" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#63e6be" />
+          <stop offset="1" stopColor="#0ca678" />
+        </linearGradient>
+      </defs>
+      <circle
+        cx="16"
+        cy="16"
+        r="9.5"
+        fill="none"
+        stroke={`url(#${gradientId("financials")})`}
+        strokeWidth="1.8"
+      />
+      <path
+        d="M11 20c1.4 1.4 3.3 2.2 5.3 2.2 3.7 0 6.7-2.2 7.7-6.2"
+        fill="none"
+        stroke="#f8f9fa"
+        strokeOpacity="0.75"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M16 9.5v13"
+        fill="none"
+        stroke="#f8f9fa"
+        strokeOpacity="0.75"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M13.5 13.5c0-1.3 1.1-2.3 2.5-2.3 1.4 0 2.5 1 2.5 2.3 0 1.3-1.1 2.3-2.5 2.3-1.4 0-2.5 1-2.5 2.3s1.1 2.3 2.5 2.3 2.5-1 2.5-2.3"
+        fill="none"
+        stroke="#f8f9fa"
+        strokeOpacity="0.6"
+        strokeWidth="1.1"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- refresh the landing experience with refined hero messaging, upgraded quick link visuals, a delivery plan section, and a white-glove CTA
- introduce a bespoke SVG icon set and updated header/user menu copy to emphasise school sign-in flows
- add a reusable RequireAuth gate and wrap students, staff, performance, events, and financial routes to require school authentication

## Testing
- pnpm lint *(fails: existing @typescript-eslint/no-explicit-any violations in legacy forms/actions)*

------
https://chatgpt.com/codex/tasks/task_e_68d99fbcd914832f9098e809c97094ca