### PR TITLE
Refine sign-in landing and secure home workspace

### DIFF
--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -1,44 +1,67 @@
 import type { Metadata } from "next";
-import PageHeader from "@/components/PageHeader";
 import SignInCard from "@/components/SignInCard";
+
+const highlights = [
+  {
+    title: "One launch unlocks every workspace",
+    blurb: "Students, staff, events, performance, and finance modules stay linked to the same Google identity.",
+  },
+  {
+    title: "Hardened for leadership teams",
+    blurb: "Role-aware dashboards, export-ready records, and an audit trail friendly interface ship as standard.",
+  },
+  {
+    title: "Always deterministic for demos",
+    blurb: "Authentication lives in secure local storage so previews stay stable while showcasing the full experience.",
+  },
+];
 
 export const metadata: Metadata = {
   title: "Sign in · Brand‑Stone School Suite",
-  description: "Authenticate with Google to access Brand‑Stone School Suite.",
+  description: "Authenticate with Google Workspace to open the Brand‑Stone home workspace.",
 };
 
 export default function SignInPage() {
   return (
-    <div className="space-y-8">
-      <PageHeader
-        title="Sign in"
-        subtitle="Authenticate with Google Workspace to access students, staff, performance, events, and financial dashboards."
+    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-[#080808]/95 px-6 py-10 text-white shadow-[0_32px_120px_-60px_rgba(217,4,41,0.6)] sm:px-10 sm:py-14 lg:px-14 lg:py-16">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(110rem_90rem_at_15%_20%,rgba(217,4,41,0.22),transparent)]"
       />
-      <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-[#2a0008]/45 via-transparent to-transparent" aria-hidden />
+      <div className="relative grid items-center gap-10 lg:grid-cols-[1.15fr_0.85fr]">
+        <div className="space-y-7">
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.28em] text-white/60">
+            <span className="h-2 w-2 rounded-full bg-[var(--brand)] shadow-[0_0_10px_rgba(217,4,41,0.8)]" aria-hidden />
+            School suite access
+          </div>
+          <div className="space-y-4">
+            <h1 className="font-display text-[clamp(2.2rem,4vw,3.2rem)] font-semibold leading-[1.05]">
+              Sign in to Brand‑Stone School Suite
+            </h1>
+            <p className="max-w-2xl text-sm text-white/70 sm:text-base">
+              Catch the full command center in a single glance. Authenticate with Google Workspace to move seamlessly from enrolment to staffing, finance, and community moments without leaving this matte cockpit.
+            </p>
+          </div>
+          <ul className="grid gap-4 text-sm text-white/70 sm:grid-cols-2">
+            {highlights.map((item) => (
+              <li key={item.title} className="rounded-2xl border border-white/10 bg-black/30 p-4">
+                <p className="font-semibold text-white">{item.title}</p>
+                <p className="mt-2 text-xs text-white/60 sm:text-sm sm:text-white/70">{item.blurb}</p>
+              </li>
+            ))}
+          </ul>
+          <div className="flex flex-wrap gap-3 pt-2 text-xs uppercase tracking-[0.28em] text-white/45">
+            <span className="inline-flex items-center gap-2">
+              <span className="h-2 w-2 rounded-full bg-[var(--brand)]" aria-hidden />Federated security
+            </span>
+            <span>Audit trail ready</span>
+            <span>Zero passwords stored</span>
+          </div>
+        </div>
         <SignInCard />
-        <aside className="card space-y-4 p-6 sm:p-8">
-          <h2 className="font-display text-xl font-semibold text-white">Why Google?</h2>
-          <p className="text-sm text-white/70">
-            Brand‑Stone uses federated Google sign-in so administrators inherit your organisation&apos;s security policies including
-            multi-factor authentication and session lifetimes.
-          </p>
-          <div className="rounded-lg border border-white/10 bg-black/40 p-4 text-xs text-white/60">
-            <p className="font-semibold uppercase tracking-wide text-white/50">Need an invite?</p>
-            <p className="mt-1">
-              Contact your district technology lead to request a Brand‑Stone workspace seat. Once invited, sign in here with the
-              same Google account.
-            </p>
-          </div>
-          <div className="rounded-lg border border-white/10 bg-black/40 p-4 text-xs text-white/60">
-            <p className="font-semibold uppercase tracking-wide text-white/50">Privacy by design</p>
-            <p className="mt-1">
-              We never store your Google password. This demo keeps the authenticated state on-device only so test builds and
-              deployments remain deterministic.
-            </p>
-          </div>
-        </aside>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
               Skip to content
             </a>
             <header className="sticky top-0 z-40 border-b border-white/10 bg-[#070707cc] backdrop-blur">
-              <div className="container flex h-16 items-center justify-between gap-4">
+              <div className="mx-auto grid h-16 w-full max-w-7xl grid-cols-[auto,1fr,auto] items-center gap-4 px-4 sm:px-6 lg:px-8">
                 <Link href="/" aria-label="Go to homepage" className="flex items-center gap-3 min-w-0">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img src="/logo.png" alt="Brand‑Stone logo" className="h-9 w-9 rounded border border-white/10 bg-black/40 p-1" />
@@ -47,15 +47,10 @@ export default function RootLayout({
                     <span className="text-xs uppercase tracking-[0.18em] text-white/60">School Suite</span>
                   </div>
                 </Link>
-                <div className="flex flex-1 items-center justify-center">
-                  <div className="hidden md:block">
-                    <Nav />
-                  </div>
+                <div className="flex items-center justify-center">
+                  <Nav />
                 </div>
-                <div className="flex items-center gap-4">
-                  <div className="md:hidden">
-                    <Nav />
-                  </div>
+                <div className="flex items-center justify-end gap-4">
                   <div className="hidden text-right text-[11px] uppercase tracking-[0.3em] text-white/45 sm:block">
                     <span className="block">Single sign-on</span>
                     <span className="block text-white/35">Google Workspace</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,20 @@
-import Hero from "@/components/Hero";
 import QuickLinks from "@/components/QuickLinks";
-import Showcase from "@/components/Showcase";
 import DashboardOverview from "@/components/DashboardOverview";
-import CTA from "@/components/CTA";
-import DeliveryPlan from "@/components/DeliveryPlan";
+import RequireAuth from "@/components/RequireAuth";
+import HomeWelcome from "@/components/HomeWelcome";
 
 export default function Home() {
   return (
-    <div className="font-sans">
-      <Hero />
-      <QuickLinks />
-      <div className="mt-10 gradient-line animate" />
-      <Showcase />
-      <DeliveryPlan />
-      <div className="mt-10 gradient-line animate" />
-      <DashboardOverview />
-      <CTA />
-    </div>
+    <RequireAuth
+      section="school control center"
+      blurb="Authenticate with Google Workspace to open the Brand‑Stone home workspace and live operational dashboards."
+    >
+      <div className="space-y-12">
+        <HomeWelcome />
+        <QuickLinks />
+        <div className="gradient-line animate" />
+        <DashboardOverview />
+      </div>
+    </RequireAuth>
   );
 }

--- a/src/components/HomeWelcome.tsx
+++ b/src/components/HomeWelcome.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { useAuth } from "@/components/AuthProvider";
+
+const snapshots = [
+  { label: "Students on roll", value: "1,204", detail: "Synced 2 min ago" },
+  { label: "Staff on duty", value: "148", detail: "HR roster confirmed" },
+  { label: "Events this week", value: "12", detail: "All cover arranged" },
+  { label: "Budget variance", value: "+3.4%", detail: "Quarter-to-date" },
+  { label: "Open interventions", value: "18", detail: "Across 7 cohorts" },
+  { label: "Transport status", value: "On schedule", detail: "9 routes live" },
+];
+
+export default function HomeWelcome() {
+  const { user } = useAuth();
+  const greetingName = useMemo(() => {
+    if (!user?.name) return "Administrator";
+    const [first] = user.name.split(" ");
+    return first ?? "Administrator";
+  }, [user?.name]);
+
+  return (
+    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-[#0a0a0a]/95 p-8 text-white shadow-[0_32px_120px_-60px_rgba(217,4,41,0.6)] sm:p-10 lg:p-12">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(110rem_90rem_at_10%_20%,rgba(217,4,41,0.18),transparent)]"
+      />
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-[#2a0008]/40 via-transparent to-transparent" aria-hidden />
+      <div className="relative flex flex-col gap-10 lg:flex-row lg:items-center">
+        <div className="flex-1 space-y-6">
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.28em] text-white/60">
+            <span className="h-2 w-2 rounded-full bg-[var(--brand)] shadow-[0_0_10px_rgba(217,4,41,0.8)]" aria-hidden />
+            School control center
+          </div>
+          <h1 className="font-display text-3xl font-semibold leading-tight sm:text-4xl">Welcome back, {greetingName}.</h1>
+          <p className="max-w-2xl text-sm text-white/70 sm:text-base">
+            The Brand‑Stone home workspace keeps every team aligned. Jump into a module, review today&apos;s metrics, or surface an action without leaving this hub.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/students"
+              className="rounded-full bg-[var(--brand)] px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-[var(--brand-500)]"
+            >
+              View students
+            </Link>
+            <Link
+              href="/events"
+              className="rounded-full border border-white/20 px-5 py-2.5 text-sm font-semibold text-white/85 transition hover:border-white/40 hover:text-white"
+            >
+              Plan an event
+            </Link>
+          </div>
+        </div>
+        <div className="grid flex-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {snapshots.map((item) => (
+            <div
+              key={item.label}
+              className="group overflow-hidden rounded-2xl border border-white/10 bg-black/30 p-4 transition hover:border-[var(--brand)]/60 hover:shadow-[0_24px_60px_-35px_rgba(217,4,41,0.55)]"
+            >
+              <div className="text-[11px] uppercase tracking-[0.28em] text-white/45">{item.label}</div>
+              <div className="mt-3 text-2xl font-semibold text-white">{item.value}</div>
+              <div className="mt-1 text-xs text-white/60">{item.detail}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- restyle the /auth/sign-in route into a focused hero that introduces the suite and surfaces the Google login card
- gate the home route behind authentication with a new home welcome module and tighter operational snapshot
- align the global header layout with the application grid for a more consistent, industry-standard shell

## Testing
- pnpm lint *(fails: existing @typescript-eslint/no-explicit-any violations in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a4b08608832f89025ca45f2ac179