### PR TITLE
Implement events management module

### DIFF
--- a/docs/product-strategy.md
+++ b/docs/product-strategy.md
@@ -1,0 +1,144 @@
+# School Management Platform – Product and Architecture Strategy
+
+## 1. Vision and Core Outcomes
+The platform centralizes academic, administrative, and financial operations for schools. It should deliver:
+- **Single source of truth** for student and staff records, academic history, finances, and events.
+- **Role-aware experience** that adapts to Admin, Teacher, Student, and Finance teams while maintaining data security.
+- **Automated insights** into performance, compliance, and financial standing through dashboards and scheduled reports.
+
+## 2. User Segments and Primary Journeys
+| Persona | Primary Goals | Key Modules |
+| --- | --- | --- |
+| **Admin** | onboard community, manage academics/finance access, oversee compliance | Registration, Academics, Staff, Finance, Reports |
+| **Teacher** | manage classrooms, capture assessments, communicate outcomes | Classes, Attendance, Question Bank, Assignments |
+| **Student** | monitor progress, complete assessments, maintain profile | Profile, Results, Tests, Assignments, E-Library |
+| **Finance Officer** | reconcile payments, generate statements, forecast budgets | Payments, Sanctions, Income/Expense Ledger |
+
+### Login and Navigation Flow (All Personas)
+1. **Authentication**
+   - Email/username + password with optional MFA.
+   - SSO-ready (SAML/OAuth) for institutions with identity providers.
+   - Passwordless invite links for first-time users (admins create accounts).
+2. **Authorization and Context Setup**
+   - Role-based access control (RBAC) seeds the user’s default workspace (school, session, term).
+   - Feature flags/gatekeeping for modules not yet purchased or enabled.
+3. **Personalized Dashboard**
+   - Snapshot cards for key actions: pending registrations (Admin), attendance submissions (Teacher), outstanding fees (Finance), new grades (Student).
+4. **Global navigation** segmented into major domains: **Individuals**, **Academic Performance**, **Events**, **Financials**, **Resources**.
+
+## 3. Platform Architecture
+### 3.1 Application Layers
+- **Client (Next.js)**: Server-side rendering for dashboards, client components for interactive tables and forms. Use Next Auth for sessions.
+- **API Gateway (Next.js App Router + Route Handlers)**: Handles REST/GraphQL endpoints, orchestrates business logic.
+- **Core Services**
+  - **Identity & Access**: authentication, roles, permissions, audit trails.
+  - **People Registry**: unified student/staff profile management, documents, guardians.
+  - **Academics**: courses, classes, attendance, assessments, automatic GPA/CGPA computation.
+  - **Finance**: fee structures, payments, sanctions, scholarships, income/expense ledger.
+  - **Content & Resources**: assignments, e-library assets, exam/test question bank.
+- **Data Layer**: PostgreSQL via Prisma ORM. Tables partitioned by domain for maintainability.
+- **Event Bus / Jobs**: queue for notifications (email/SMS), report generation, grade calculations.
+
+### 3.2 Cross-Cutting Concerns
+- **Audit Logging** for all CRUD operations on sensitive data.
+- **Data Residency** using institution-level tenancy (school_id column), enabling multi-school support.
+- **Validation** with shared schema (Zod/TypeScript types) for consistency across client/server.
+- **File Storage** using S3-compatible service for photos, certificates, documents.
+- **Analytics** using scheduled jobs to precompute dashboards and send alerts.
+
+## 4. Data Model Blueprint
+The following high-level schema guides detailed modeling (all records scoped by `school_id`).
+
+### Core Entities
+- `users` (auth credentials, role assignments)
+- `people` (common bio data, linked to users when applicable)
+- `students`, `staff` (extended attributes)
+- `guardians` and `student_guardian_links`
+- `classes`, `subjects`, `enrollments`
+- `assessments` (tests, exams, assignments) with components for scores, weighting
+- `attendance_records`
+- `fees`, `dues`, `payments`, `scholarships`
+- `sanctions` (disciplinary or financial)
+- `documents` (certificates, medical reports)
+- `library_assets`, `borrow_transactions`
+- `question_bank_items`, `question_sets`
+- `events` (calendar, extracurricular activities)
+- `payroll_runs`, `salary_components`
+
+### Derived Views & Automations
+- **Performance snapshots**: materialized views for term CGPA, grade distribution.
+- **Financial standing**: outstanding balances by student, department, and overall.
+- **Compliance reports**: expired documents, pending sanctions, attendance anomalies.
+
+## 5. Module Breakdown and User Journeys
+### 5.1 Individuals
+- **Directory** with advanced filters (status, department, class, role, sanctions).
+- **Profile Pages** for students and staff with tabs: Bio, Academics, Financials, Documents.
+- **Bulk Operations**: CSV import/export, mass status updates, communications.
+
+### 5.2 Academics & Performance
+1. **Teacher Workflow**
+   - View assigned classes ➜ take attendance ➜ create/update assessments ➜ enter scores ➜ publish results.
+   - Integrate question bank into tests/assignments; support randomization and timed exams.
+2. **Admin Oversight**
+   - Configure grading scales, weightings, academic calendar.
+   - Approve published results, trigger report card generation.
+3. **Student Experience**
+   - Access timetable, assessments, feedback.
+   - Run analytics: trend lines, CGPA computation, degree classification predictions.
+
+### 5.3 Financials
+- **Fee Management**: define fee items per session/term/class; schedule invoices.
+- **Payment Tracking**: log receipts (manual/bank integration), handle partial payments, scholarships.
+- **Sanctions & Waivers**: issue fines or restrictions; workflow for resolution.
+- **Reporting**: income vs expenses, outstanding balances, cash flow forecasts.
+- **Payroll**: staff salary structures, deductions, approvals, payout logs.
+
+### 5.4 Events & Communication
+- Academic calendar with reminders.
+- Notifications center (email/SMS/in-app) with templates per event (missed attendance, fee reminders).
+- Event registrations and attendance for extracurricular activities.
+
+### 5.5 Resources & E-Library
+- Curated digital library with categories, permissions, download tracking.
+- Assignment submissions with plagiarism checks (integration-ready).
+
+## 6. Integration and Extensibility Plan
+- **API Access**: provide secure API keys/webhooks for SIS/LMS interoperability.
+- **Third-Party Services**: payment gateways, SMS providers, document verification.
+- **Plugin Architecture**: allow institutions to enable optional modules (transport, hostel management) later.
+
+## 7. Implementation Roadmap
+1. **Foundation (Milestone 1)**
+   - Set up authentication, RBAC, tenant-aware data model.
+   - Build core directories (students, staff) with CRUD and document upload.
+   - Establish finance ledger basics (fee catalog, payment receipts).
+2. **Academic Core (Milestone 2)**
+   - Classes, subjects, enrollment, attendance, assessment entry.
+   - Performance computation service; student dashboards.
+3. **Financial Expansion (Milestone 3)**
+   - Dues, medical fees, sanctions workflows.
+   - Payroll module with salary components and reports.
+4. **Experience Enhancements (Milestone 4)**
+   - E-library, assignments, question bank, notifications.
+   - Report card automation, analytics dashboards.
+5. **Optimization & Integrations (Milestone 5)**
+   - API endpoints for partners, data import/export tooling.
+   - Audit logs, advanced search, custom reporting.
+
+## 8. Security and Compliance Considerations
+- Enforce least-privilege access with RBAC and resource-level permissions.
+- Encrypt sensitive fields (medical info, salaries) at rest; TLS in transit.
+- Comply with local privacy laws (e.g., NDPR, GDPR) via consent management and data retention policies.
+- Provide disaster recovery via automated backups and replication.
+
+## 9. Metrics and Success Criteria
+- **Operational**: onboarding time per student/staff, time-to-publish results, payment reconciliation time.
+- **Adoption**: daily active users per role, percentage of modules actively used.
+- **Outcomes**: reduction in outstanding fees, improved attendance reporting accuracy, faster payroll cycles.
+
+## 10. Next Steps
+- Validate data model with stakeholders and refine edge cases (part-time staff, special programs).
+- Produce UI wireframes aligned with journeys above.
+- Prioritize MVP scope against timeline and available engineering resources.
+

--- a/src/app/events/[id]/edit/page.tsx
+++ b/src/app/events/[id]/edit/page.tsx
@@ -1,0 +1,27 @@
+import EventForm from "@/components/EventForm";
+import { getEvent, updateEvent } from "../../actions";
+
+export default async function EditEventPage({ params }: { params: { id: string } }) {
+  const event = await getEvent(params.id);
+  if (!event) {
+    return <div className="text-sm">Event not found.</div>;
+  }
+
+  return (
+    <section className="space-y-6 max-w-2xl">
+      <h1 className="text-xl font-semibold">Edit Event</h1>
+      <EventForm
+        action={updateEvent.bind(null, event.id)}
+        initial={{
+          id: event.id,
+          title: event.title,
+          date: event.date as string | null,
+          description: event.description as string | null,
+          audience: Array.isArray(event.audience) ? (event.audience as string[]) : null,
+        }}
+        redirectTo={`/events/${event.id}`}
+        submitLabel="Update"
+      />
+    </section>
+  );
+}

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { getEvent, deleteEvent } from "../actions";
+import Badge from "@/components/ui/Badge";
+import Button from "@/components/ui/Button";
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return {
+    dateLabel: dateFormatter.format(date),
+    timeLabel: timeFormatter.format(date),
+    status: date.getTime() >= Date.now() ? "upcoming" : "past",
+  } as const;
+}
+
+export default async function EventDetailPage({ params }: { params: { id: string } }) {
+  const event = await getEvent(params.id);
+
+  if (!event) {
+    return <div className="text-sm">Event not found.</div>;
+  }
+
+  const formatted = formatDate(event.date as string | undefined);
+
+  return (
+    <section className="space-y-6 max-w-3xl">
+      <div className="card space-y-4 p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold">{event.title}</h1>
+            {formatted ? (
+              <div className="flex flex-wrap items-center gap-3 text-sm text-white/70">
+                <span className="font-medium text-white">{formatted.dateLabel}</span>
+                <span>•</span>
+                <span>{formatted.timeLabel}</span>
+                <Badge color={formatted.status === "upcoming" ? "green" : "blue"}>
+                  {formatted.status === "upcoming" ? "Upcoming" : "Completed"}
+                </Badge>
+              </div>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <Link href={`/events/${event.id}/edit`}>
+              <Button variant="secondary">Edit</Button>
+            </Link>
+            <form action={deleteEvent.bind(null, event.id)}>
+              <Button variant="danger">Delete</Button>
+            </form>
+          </div>
+        </div>
+        <div className="text-sm leading-relaxed text-white/80">
+          {event.description ? event.description : "No description provided for this event."}
+        </div>
+        {Array.isArray(event.audience) && event.audience.length ? (
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-wider text-white/40">Audience</div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {event.audience.map((value) => (
+                <span
+                  key={value}
+                  className="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/70"
+                >
+                  {value}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/app/events/actions.ts
+++ b/src/app/events/actions.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { prisma } from "@/lib/db";
+import { EventInputSchema } from "@/lib/validation";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+function normaliseAudience(audience?: string | null) {
+  if (!audience) return undefined;
+  const entries = audience
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return entries.length ? entries : undefined;
+}
+
+function toIsoString(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Invalid date");
+  }
+  return date.toISOString();
+}
+
+export async function listEvents() {
+  return prisma.eventItem.findMany({ orderBy: { date: "asc" } });
+}
+
+export async function getEvent(id: string) {
+  return prisma.eventItem.findUnique({ where: { id } });
+}
+
+export async function createEvent(formData: FormData) {
+  const parsed = EventInputSchema.safeParse(Object.fromEntries(formData.entries()));
+  if (!parsed.success) {
+    const message = parsed.error.issues.map((issue) => issue.message).join(", ");
+    const errors = parsed.error.flatten().fieldErrors as Record<string, string[]>;
+    return { success: false, error: message, errors } as const;
+  }
+
+  const { title, date, description, audience } = parsed.data;
+
+  const created = await prisma.eventItem.create({
+    data: {
+      title,
+      date: toIsoString(date),
+      description: description || undefined,
+      audience: normaliseAudience(audience),
+    },
+  });
+
+  revalidatePath("/events");
+  return { success: true, id: created.id } as const;
+}
+
+export async function updateEvent(id: string, formData: FormData) {
+  const parsed = EventInputSchema.safeParse(Object.fromEntries(formData.entries()));
+  if (!parsed.success) {
+    const message = parsed.error.issues.map((issue) => issue.message).join(", ");
+    const errors = parsed.error.flatten().fieldErrors as Record<string, string[]>;
+    return { success: false, error: message, errors } as const;
+  }
+
+  const { title, date, description, audience } = parsed.data;
+
+  const updated = await prisma.eventItem.update({
+    where: { id },
+    data: {
+      title,
+      date: toIsoString(date),
+      description: description || undefined,
+      audience: normaliseAudience(audience) ?? null,
+    },
+  });
+
+  revalidatePath("/events");
+  revalidatePath(`/events/${id}`);
+  return { success: true, id: updated.id } as const;
+}
+
+export async function deleteEvent(id: string) {
+  await prisma.eventItem.delete({ where: { id } });
+  revalidatePath("/events");
+  redirect("/events");
+}

--- a/src/app/events/loading.tsx
+++ b/src/app/events/loading.tsx
@@ -1,0 +1,9 @@
+export default function LoadingEvents() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      <div className="h-8 w-48 rounded bg-white/10" />
+      <div className="h-10 w-full rounded bg-white/10" />
+      <div className="h-64 w-full rounded bg-white/10" />
+    </div>
+  );
+}

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -1,0 +1,11 @@
+import EventForm from "@/components/EventForm";
+import { createEvent } from "../actions";
+
+export default function NewEventPage() {
+  return (
+    <section className="space-y-6 max-w-2xl">
+      <h1 className="text-xl font-semibold">Schedule Event</h1>
+      <EventForm action={createEvent} redirectTo="/events" submitLabel="Schedule" />
+    </section>
+  );
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,10 +1,31 @@
+import Link from "next/link";
+import { listEvents } from "./actions";
 import PageHeader from "@/components/PageHeader";
+import EventListClient, { type EventRecord } from "@/components/EventListClient";
 
-export default function EventsPage() {
+export default async function EventsPage() {
+  const events = await listEvents();
+  const records: EventRecord[] = events.map((event) => ({
+    id: event.id,
+    title: event.title,
+    date: event.date as string,
+    description: event.description as string | null | undefined,
+    audience: Array.isArray(event.audience) ? (event.audience as string[]) : null,
+  }));
+
   return (
     <section className="space-y-6">
       <PageHeader title="Events" subtitle="Schedule school events and track important dates." />
-      <div className="card p-4 text-sm">Coming soon: calendar view and event list.</div>
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Events</h1>
+        <Link
+          href="/events/new"
+          className="rounded bg-black text-white px-3 py-1 text-sm hover:bg-black/80"
+        >
+          Schedule Event
+        </Link>
+      </header>
+      <EventListClient events={records} />
     </section>
   );
 }

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useActionState } from "react";
+import { useRouter } from "next/navigation";
+import Input from "@/components/ui/Input";
+import Label from "@/components/ui/Label";
+import Button from "@/components/ui/Button";
+import { useToast } from "@/components/ToastProvider";
+
+function formatForInput(value?: string | null) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+type ActionResult = {
+  success: boolean;
+  id?: string;
+  error?: string;
+  errors?: Record<string, string[]>;
+};
+
+type Action = (formData: FormData) => Promise<ActionResult>;
+
+type EventFormProps = {
+  action: Action;
+  initial?: {
+    id?: string;
+    title?: string;
+    date?: string | null;
+    description?: string | null;
+    audience?: string[] | null;
+  };
+  redirectTo: string;
+  submitLabel?: string;
+};
+
+export default function EventForm({ action, initial, redirectTo, submitLabel = "Save" }: EventFormProps) {
+  const router = useRouter();
+  const toast = useToast();
+  const [state, formAction, pending] = useActionState<ActionResult | null>(async (_prev, formData: FormData) => {
+    const response = await action(formData);
+    if (response.success) {
+      toast.addToast({ title: "Saved", description: "Event saved successfully", variant: "success" });
+      router.push(redirectTo.replace(":id", response.id || ""));
+      router.refresh();
+    }
+    return response;
+  }, null);
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {state?.error ? <div className="text-sm text-red-500">{state.error}</div> : null}
+      <Label>
+        <span>Title</span>
+        <Input name="title" defaultValue={initial?.title} placeholder="Ceremony, fixture, or announcement" />
+        {state?.errors?.title?.[0] ? <span className="text-red-500">{state.errors.title[0]}</span> : null}
+      </Label>
+      <Label>
+        <span>Date &amp; time</span>
+        <Input type="datetime-local" name="date" defaultValue={formatForInput(initial?.date)} />
+        {state?.errors?.date?.[0] ? <span className="text-red-500">{state.errors.date[0]}</span> : null}
+      </Label>
+      <Label>
+        <span>Description</span>
+        <textarea
+          name="description"
+          defaultValue={initial?.description ?? ""}
+          placeholder="Context, objectives, dress code, or logistics"
+          rows={3}
+          className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/60 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand)]"
+        />
+        {state?.errors?.description?.[0] ? <span className="text-red-500">{state.errors.description[0]}</span> : null}
+      </Label>
+      <Label>
+        <span>Audience</span>
+        <Input
+          name="audience"
+          defaultValue={Array.isArray(initial?.audience) ? initial.audience.join(", ") : ""}
+          placeholder="Students, Guardians, Teachers"
+        />
+        <span className="text-xs text-white/50">Separate multiple audiences with commas.</span>
+        {state?.errors?.audience?.[0] ? <span className="text-red-500">{state.errors.audience[0]}</span> : null}
+      </Label>
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : submitLabel}
+        </Button>
+        <Button type="button" variant="secondary" onClick={() => router.back()}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/EventListClient.tsx
+++ b/src/components/EventListClient.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import Input from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
+import Badge from "@/components/ui/Badge";
+
+export type EventRecord = {
+  id: string;
+  title: string;
+  date: string;
+  description?: string | null;
+  audience?: string[] | null;
+};
+
+type TimelineEvent = EventRecord & {
+  dateObject: Date;
+  dateLabel: string;
+  timeLabel: string;
+  relative: string;
+  status: "upcoming" | "past";
+};
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+const relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+function formatRelative(date: Date) {
+  const now = Date.now();
+  const diff = date.getTime() - now;
+  const minutes = Math.round(diff / (1000 * 60));
+  if (Math.abs(minutes) < 60) {
+    return relativeFormatter.format(minutes, "minute");
+  }
+  const hours = Math.round(minutes / 60);
+  if (Math.abs(hours) < 24) {
+    return relativeFormatter.format(hours, "hour");
+  }
+  const days = Math.round(hours / 24);
+  if (Math.abs(days) < 30) {
+    return relativeFormatter.format(days, "day");
+  }
+  const months = Math.round(days / 30);
+  return relativeFormatter.format(months, "month");
+}
+
+function normaliseEvent(record: EventRecord): TimelineEvent | null {
+  const dateObject = new Date(record.date);
+  if (Number.isNaN(dateObject.getTime())) {
+    return null;
+  }
+  const status = dateObject.getTime() >= Date.now() ? "upcoming" : "past";
+  return {
+    ...record,
+    dateObject,
+    status,
+    dateLabel: dateFormatter.format(dateObject),
+    timeLabel: timeFormatter.format(dateObject),
+    relative: formatRelative(dateObject),
+  };
+}
+
+function getAudienceOptions(events: TimelineEvent[]) {
+  const entries = new Set<string>();
+  for (const event of events) {
+    for (const value of event.audience ?? []) {
+      entries.add(value);
+    }
+  }
+  return Array.from(entries.values()).sort();
+}
+
+export default function EventListClient({ events }: { events: EventRecord[] }) {
+  const [query, setQuery] = useState("");
+  const [view, setView] = useState<"upcoming" | "past" | "all">("upcoming");
+  const [audience, setAudience] = useState("all");
+
+  const timelineEvents = useMemo(() => {
+    return events
+      .map(normaliseEvent)
+      .filter((value): value is TimelineEvent => Boolean(value))
+      .sort((a, b) => a.dateObject.getTime() - b.dateObject.getTime());
+  }, [events]);
+
+  const audienceOptions = useMemo(() => getAudienceOptions(timelineEvents), [timelineEvents]);
+
+  const filtered = useMemo(() => {
+    const queryLower = query.trim().toLowerCase();
+    return timelineEvents.filter((event) => {
+      if (view !== "all" && event.status !== view) {
+        return false;
+      }
+      if (audience !== "all") {
+        if (!event.audience?.some((value) => value === audience)) {
+          return false;
+        }
+      }
+      if (!queryLower) {
+        return true;
+      }
+      const haystack = [event.title, event.description ?? "", (event.audience ?? []).join(" ")]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(queryLower);
+    });
+  }, [timelineEvents, query, view, audience]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-3 text-sm">
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search title, audience, or description"
+          className="min-w-[220px]"
+        />
+        <Select value={view} onChange={(event) => setView(event.target.value as typeof view)}>
+          <option value="upcoming">Upcoming</option>
+          <option value="past">Past</option>
+          <option value="all">All</option>
+        </Select>
+        <Select value={audience} onChange={(event) => setAudience(event.target.value)}>
+          <option value="all">All audiences</option>
+          {audienceOptions.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </Select>
+      </div>
+
+      <div className="space-y-3">
+        {filtered.length === 0 ? (
+          <div className="card p-6 text-sm text-white/70">
+            <p className="font-medium text-white">No events yet.</p>
+            <p className="mt-1">
+              Adjust your filters or schedule a new event to populate the communications timeline.
+            </p>
+          </div>
+        ) : (
+          <ol className="space-y-4">
+            {filtered.map((event) => (
+              <li key={event.id} className="relative">
+                <Link
+                  href={`/events/${event.id}`}
+                  className="group block rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-[var(--brand)]/60 hover:bg-white/10"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="text-lg font-semibold text-white group-hover:text-[var(--brand-500)]">
+                          {event.title}
+                        </h2>
+                        <Badge color={event.status === "upcoming" ? "green" : "blue"}>{event.relative}</Badge>
+                      </div>
+                      <p className="mt-1 text-sm text-white/70 leading-relaxed">
+                        {event.description || "No description provided."}
+                      </p>
+                      {event.audience?.length ? (
+                        <div className="mt-2 flex flex-wrap gap-2 text-xs text-white/60">
+                          {event.audience.map((value) => (
+                            <span
+                              key={value}
+                              className="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-2 py-1"
+                            >
+                              {value}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="shrink-0 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-right text-sm text-white/80">
+                      <div className="font-semibold text-white">{event.dateLabel}</div>
+                      <div>{event.timeLabel}</div>
+                    </div>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,6 @@
 import {
   AcademicRecord,
+  EventItem,
   FinancialEntry,
   MockData,
   Student,
@@ -34,9 +35,9 @@ const generateId = () => `id_${Math.random().toString(36).slice(2, 10)}`;
 
 const now = () => new Date().toISOString();
 
-type TableItem = Student | Staff | FinancialEntry | AcademicRecord;
+type TableItem = Student | Staff | FinancialEntry | AcademicRecord | EventItem;
 
-type TableName = "students" | "staff" | "financialEntries" | "academicRecords";
+type TableName = "students" | "staff" | "financialEntries" | "academicRecords" | "events";
 
 interface TableConfig<T extends TableItem> {
   name: TableName;
@@ -183,6 +184,7 @@ interface PrismaMock {
   staff: InMemoryTable<Staff>;
   financialEntry: InMemoryTable<FinancialEntry>;
   academicRecord: InMemoryTable<AcademicRecord>;
+  eventItem: InMemoryTable<EventItem>;
 }
 
 declare global {
@@ -204,6 +206,7 @@ const createPrisma = (data: MockData): PrismaMock => ({
       return {};
     },
   }),
+  eventItem: new InMemoryTable<EventItem>(data, { name: "events" }),
 });
 
 if (!globalThis.__mockData) {

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -94,6 +94,16 @@ export interface AcademicRecord {
   updatedAt: string;
 }
 
+export interface EventItem {
+  id: string;
+  title: string;
+  date: string;
+  description?: string | null;
+  audience?: string[] | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 const now = () => new Date().toISOString();
 
 export interface MockData {
@@ -101,6 +111,7 @@ export interface MockData {
   staff: Staff[];
   financialEntries: FinancialEntry[];
   academicRecords: AcademicRecord[];
+  events: EventItem[];
 }
 
 const today = new Date();
@@ -226,6 +237,35 @@ export const initialData: MockData = {
       attendance: 95,
       grade: "A",
       cgpa: 4.8,
+      createdAt: now(),
+      updatedAt: now(),
+    },
+  ],
+  events: [
+    {
+      id: "evt_1",
+      title: "PTA General Assembly",
+      date: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 7).toISOString(),
+      description: "Quarterly briefing with guardians on academic progress and upcoming projects.",
+      audience: ["Guardians", "Teachers"],
+      createdAt: now(),
+      updatedAt: now(),
+    },
+    {
+      id: "evt_2",
+      title: "Science Fair Showcase",
+      date: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 21).toISOString(),
+      description: "Students present STEM innovations for community judging.",
+      audience: ["Students", "Community"],
+      createdAt: now(),
+      updatedAt: now(),
+    },
+    {
+      id: "evt_3",
+      title: "Teachers' Capacity Workshop",
+      date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 12).toISOString(),
+      description: "Professional development on differentiated learning and assessment.",
+      audience: ["Teachers"],
       createdAt: now(),
       updatedAt: now(),
     },

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -95,3 +95,19 @@ export const AcademicInputSchema = z.object({
 });
 
 export type AcademicInput = z.infer<typeof AcademicInputSchema>;
+
+export const EventInputSchema = z.object({
+  title: z.string().trim().min(1, "Title is required"),
+  date: z
+    .string()
+    .trim()
+    .min(1, "Date is required")
+    .refine((value) => {
+      const timestamp = Date.parse(value);
+      return Number.isFinite(timestamp);
+    }, "Enter a valid date"),
+  description: z.string().optional().or(z.literal("")),
+  audience: z.string().optional().or(z.literal("")),
+});
+
+export type EventInput = z.infer<typeof EventInputSchema>;


### PR DESCRIPTION
## Summary
- add server actions, validation, and mock data support for scheduling school events
- replace the events landing page with a filterable timeline and create/edit workflows
- introduce reusable event form and client-side listing components for audiences and details

## Testing
- pnpm lint *(fails: existing lint violations for @typescript-eslint/no-explicit-any across legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68da0be0f90c832f99966185c283e4ac