### PR TITLE
Refine core modules with premium dashboards

### DIFF
--- a/docs/product-strategy.md
+++ b/docs/product-strategy.md
@@ -1,0 +1,144 @@
+# School Management Platform – Product and Architecture Strategy
+
+## 1. Vision and Core Outcomes
+The platform centralizes academic, administrative, and financial operations for schools. It should deliver:
+- **Single source of truth** for student and staff records, academic history, finances, and events.
+- **Role-aware experience** that adapts to Admin, Teacher, Student, and Finance teams while maintaining data security.
+- **Automated insights** into performance, compliance, and financial standing through dashboards and scheduled reports.
+
+## 2. User Segments and Primary Journeys
+| Persona | Primary Goals | Key Modules |
+| --- | --- | --- |
+| **Admin** | onboard community, manage academics/finance access, oversee compliance | Registration, Academics, Staff, Finance, Reports |
+| **Teacher** | manage classrooms, capture assessments, communicate outcomes | Classes, Attendance, Question Bank, Assignments |
+| **Student** | monitor progress, complete assessments, maintain profile | Profile, Results, Tests, Assignments, E-Library |
+| **Finance Officer** | reconcile payments, generate statements, forecast budgets | Payments, Sanctions, Income/Expense Ledger |
+
+### Login and Navigation Flow (All Personas)
+1. **Authentication**
+   - Email/username + password with optional MFA.
+   - SSO-ready (SAML/OAuth) for institutions with identity providers.
+   - Passwordless invite links for first-time users (admins create accounts).
+2. **Authorization and Context Setup**
+   - Role-based access control (RBAC) seeds the user’s default workspace (school, session, term).
+   - Feature flags/gatekeeping for modules not yet purchased or enabled.
+3. **Personalized Dashboard**
+   - Snapshot cards for key actions: pending registrations (Admin), attendance submissions (Teacher), outstanding fees (Finance), new grades (Student).
+4. **Global navigation** segmented into major domains: **Individuals**, **Academic Performance**, **Events**, **Financials**, **Resources**.
+
+## 3. Platform Architecture
+### 3.1 Application Layers
+- **Client (Next.js)**: Server-side rendering for dashboards, client components for interactive tables and forms. Use Next Auth for sessions.
+- **API Gateway (Next.js App Router + Route Handlers)**: Handles REST/GraphQL endpoints, orchestrates business logic.
+- **Core Services**
+  - **Identity & Access**: authentication, roles, permissions, audit trails.
+  - **People Registry**: unified student/staff profile management, documents, guardians.
+  - **Academics**: courses, classes, attendance, assessments, automatic GPA/CGPA computation.
+  - **Finance**: fee structures, payments, sanctions, scholarships, income/expense ledger.
+  - **Content & Resources**: assignments, e-library assets, exam/test question bank.
+- **Data Layer**: PostgreSQL via Prisma ORM. Tables partitioned by domain for maintainability.
+- **Event Bus / Jobs**: queue for notifications (email/SMS), report generation, grade calculations.
+
+### 3.2 Cross-Cutting Concerns
+- **Audit Logging** for all CRUD operations on sensitive data.
+- **Data Residency** using institution-level tenancy (school_id column), enabling multi-school support.
+- **Validation** with shared schema (Zod/TypeScript types) for consistency across client/server.
+- **File Storage** using S3-compatible service for photos, certificates, documents.
+- **Analytics** using scheduled jobs to precompute dashboards and send alerts.
+
+## 4. Data Model Blueprint
+The following high-level schema guides detailed modeling (all records scoped by `school_id`).
+
+### Core Entities
+- `users` (auth credentials, role assignments)
+- `people` (common bio data, linked to users when applicable)
+- `students`, `staff` (extended attributes)
+- `guardians` and `student_guardian_links`
+- `classes`, `subjects`, `enrollments`
+- `assessments` (tests, exams, assignments) with components for scores, weighting
+- `attendance_records`
+- `fees`, `dues`, `payments`, `scholarships`
+- `sanctions` (disciplinary or financial)
+- `documents` (certificates, medical reports)
+- `library_assets`, `borrow_transactions`
+- `question_bank_items`, `question_sets`
+- `events` (calendar, extracurricular activities)
+- `payroll_runs`, `salary_components`
+
+### Derived Views & Automations
+- **Performance snapshots**: materialized views for term CGPA, grade distribution.
+- **Financial standing**: outstanding balances by student, department, and overall.
+- **Compliance reports**: expired documents, pending sanctions, attendance anomalies.
+
+## 5. Module Breakdown and User Journeys
+### 5.1 Individuals
+- **Directory** with advanced filters (status, department, class, role, sanctions).
+- **Profile Pages** for students and staff with tabs: Bio, Academics, Financials, Documents.
+- **Bulk Operations**: CSV import/export, mass status updates, communications.
+
+### 5.2 Academics & Performance
+1. **Teacher Workflow**
+   - View assigned classes ➜ take attendance ➜ create/update assessments ➜ enter scores ➜ publish results.
+   - Integrate question bank into tests/assignments; support randomization and timed exams.
+2. **Admin Oversight**
+   - Configure grading scales, weightings, academic calendar.
+   - Approve published results, trigger report card generation.
+3. **Student Experience**
+   - Access timetable, assessments, feedback.
+   - Run analytics: trend lines, CGPA computation, degree classification predictions.
+
+### 5.3 Financials
+- **Fee Management**: define fee items per session/term/class; schedule invoices.
+- **Payment Tracking**: log receipts (manual/bank integration), handle partial payments, scholarships.
+- **Sanctions & Waivers**: issue fines or restrictions; workflow for resolution.
+- **Reporting**: income vs expenses, outstanding balances, cash flow forecasts.
+- **Payroll**: staff salary structures, deductions, approvals, payout logs.
+
+### 5.4 Events & Communication
+- Academic calendar with reminders.
+- Notifications center (email/SMS/in-app) with templates per event (missed attendance, fee reminders).
+- Event registrations and attendance for extracurricular activities.
+
+### 5.5 Resources & E-Library
+- Curated digital library with categories, permissions, download tracking.
+- Assignment submissions with plagiarism checks (integration-ready).
+
+## 6. Integration and Extensibility Plan
+- **API Access**: provide secure API keys/webhooks for SIS/LMS interoperability.
+- **Third-Party Services**: payment gateways, SMS providers, document verification.
+- **Plugin Architecture**: allow institutions to enable optional modules (transport, hostel management) later.
+
+## 7. Implementation Roadmap
+1. **Foundation (Milestone 1)**
+   - Set up authentication, RBAC, tenant-aware data model.
+   - Build core directories (students, staff) with CRUD and document upload.
+   - Establish finance ledger basics (fee catalog, payment receipts).
+2. **Academic Core (Milestone 2)**
+   - Classes, subjects, enrollment, attendance, assessment entry.
+   - Performance computation service; student dashboards.
+3. **Financial Expansion (Milestone 3)**
+   - Dues, medical fees, sanctions workflows.
+   - Payroll module with salary components and reports.
+4. **Experience Enhancements (Milestone 4)**
+   - E-library, assignments, question bank, notifications.
+   - Report card automation, analytics dashboards.
+5. **Optimization & Integrations (Milestone 5)**
+   - API endpoints for partners, data import/export tooling.
+   - Audit logs, advanced search, custom reporting.
+
+## 8. Security and Compliance Considerations
+- Enforce least-privilege access with RBAC and resource-level permissions.
+- Encrypt sensitive fields (medical info, salaries) at rest; TLS in transit.
+- Comply with local privacy laws (e.g., NDPR, GDPR) via consent management and data retention policies.
+- Provide disaster recovery via automated backups and replication.
+
+## 9. Metrics and Success Criteria
+- **Operational**: onboarding time per student/staff, time-to-publish results, payment reconciliation time.
+- **Adoption**: daily active users per role, percentage of modules actively used.
+- **Outcomes**: reduction in outstanding fees, improved attendance reporting accuracy, faster payroll cycles.
+
+## 10. Next Steps
+- Validate data model with stakeholders and refine edge cases (part-time staff, special programs).
+- Produce UI wireframes aligned with journeys above.
+- Prioritize MVP scope against timeline and available engineering resources.
+

--- a/src/app/events/[id]/edit/page.tsx
+++ b/src/app/events/[id]/edit/page.tsx
@@ -1,0 +1,27 @@
+import EventForm from "@/components/EventForm";
+import { getEvent, updateEvent } from "../../actions";
+
+export default async function EditEventPage({ params }: { params: { id: string } }) {
+  const event = await getEvent(params.id);
+  if (!event) {
+    return <div className="text-sm">Event not found.</div>;
+  }
+
+  return (
+    <section className="space-y-6 max-w-2xl">
+      <h1 className="text-xl font-semibold">Edit Event</h1>
+      <EventForm
+        action={updateEvent.bind(null, event.id)}
+        initial={{
+          id: event.id,
+          title: event.title,
+          date: event.date as string | null,
+          description: event.description as string | null,
+          audience: Array.isArray(event.audience) ? (event.audience as string[]) : null,
+        }}
+        redirectTo={`/events/${event.id}`}
+        submitLabel="Update"
+      />
+    </section>
+  );
+}

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { getEvent, deleteEvent } from "../actions";
+import Badge from "@/components/ui/Badge";
+import Button from "@/components/ui/Button";
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return {
+    dateLabel: dateFormatter.format(date),
+    timeLabel: timeFormatter.format(date),
+    status: date.getTime() >= Date.now() ? "upcoming" : "past",
+  } as const;
+}
+
+export default async function EventDetailPage({ params }: { params: { id: string } }) {
+  const event = await getEvent(params.id);
+
+  if (!event) {
+    return <div className="text-sm">Event not found.</div>;
+  }
+
+  const formatted = formatDate(event.date as string | undefined);
+
+  return (
+    <section className="space-y-6 max-w-3xl">
+      <div className="card space-y-4 p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold">{event.title}</h1>
+            {formatted ? (
+              <div className="flex flex-wrap items-center gap-3 text-sm text-white/70">
+                <span className="font-medium text-white">{formatted.dateLabel}</span>
+                <span>•</span>
+                <span>{formatted.timeLabel}</span>
+                <Badge color={formatted.status === "upcoming" ? "green" : "blue"}>
+                  {formatted.status === "upcoming" ? "Upcoming" : "Completed"}
+                </Badge>
+              </div>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <Link href={`/events/${event.id}/edit`}>
+              <Button variant="secondary">Edit</Button>
+            </Link>
+            <form action={deleteEvent.bind(null, event.id)}>
+              <Button variant="danger">Delete</Button>
+            </form>
+          </div>
+        </div>
+        <div className="text-sm leading-relaxed text-white/80">
+          {event.description ? event.description : "No description provided for this event."}
+        </div>
+        {Array.isArray(event.audience) && event.audience.length ? (
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-wider text-white/40">Audience</div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {event.audience.map((value) => (
+                <span
+                  key={value}
+                  className="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/70"
+                >
+                  {value}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/app/events/actions.ts
+++ b/src/app/events/actions.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { prisma } from "@/lib/db";
+import { EventInputSchema } from "@/lib/validation";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+function normaliseAudience(audience?: string | null) {
+  if (!audience) return undefined;
+  const entries = audience
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return entries.length ? entries : undefined;
+}
+
+function toIsoString(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Invalid date");
+  }
+  return date.toISOString();
+}
+
+export async function listEvents() {
+  return prisma.eventItem.findMany({ orderBy: { date: "asc" } });
+}
+
+export async function getEvent(id: string) {
+  return prisma.eventItem.findUnique({ where: { id } });
+}
+
+export async function createEvent(formData: FormData) {
+  const parsed = EventInputSchema.safeParse(Object.fromEntries(formData.entries()));
+  if (!parsed.success) {
+    const message = parsed.error.issues.map((issue) => issue.message).join(", ");
+    const errors = parsed.error.flatten().fieldErrors as Record<string, string[]>;
+    return { success: false, error: message, errors } as const;
+  }
+
+  const { title, date, description, audience } = parsed.data;
+
+  const created = await prisma.eventItem.create({
+    data: {
+      title,
+      date: toIsoString(date),
+      description: description || undefined,
+      audience: normaliseAudience(audience),
+    },
+  });
+
+  revalidatePath("/events");
+  return { success: true, id: created.id } as const;
+}
+
+export async function updateEvent(id: string, formData: FormData) {
+  const parsed = EventInputSchema.safeParse(Object.fromEntries(formData.entries()));
+  if (!parsed.success) {
+    const message = parsed.error.issues.map((issue) => issue.message).join(", ");
+    const errors = parsed.error.flatten().fieldErrors as Record<string, string[]>;
+    return { success: false, error: message, errors } as const;
+  }
+
+  const { title, date, description, audience } = parsed.data;
+
+  const updated = await prisma.eventItem.update({
+    where: { id },
+    data: {
+      title,
+      date: toIsoString(date),
+      description: description || undefined,
+      audience: normaliseAudience(audience) ?? null,
+    },
+  });
+
+  revalidatePath("/events");
+  revalidatePath(`/events/${id}`);
+  return { success: true, id: updated.id } as const;
+}
+
+export async function deleteEvent(id: string) {
+  await prisma.eventItem.delete({ where: { id } });
+  revalidatePath("/events");
+  redirect("/events");
+}

--- a/src/app/events/loading.tsx
+++ b/src/app/events/loading.tsx
@@ -1,0 +1,9 @@
+export default function LoadingEvents() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      <div className="h-8 w-48 rounded bg-white/10" />
+      <div className="h-10 w-full rounded bg-white/10" />
+      <div className="h-64 w-full rounded bg-white/10" />
+    </div>
+  );
+}

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -1,0 +1,11 @@
+import EventForm from "@/components/EventForm";
+import { createEvent } from "../actions";
+
+export default function NewEventPage() {
+  return (
+    <section className="space-y-6 max-w-2xl">
+      <h1 className="text-xl font-semibold">Schedule Event</h1>
+      <EventForm action={createEvent} redirectTo="/events" submitLabel="Schedule" />
+    </section>
+  );
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,10 +1,31 @@
+import Link from "next/link";
+import { listEvents } from "./actions";
 import PageHeader from "@/components/PageHeader";
+import EventListClient, { type EventRecord } from "@/components/EventListClient";
 
-export default function EventsPage() {
+export default async function EventsPage() {
+  const events = await listEvents();
+  const records: EventRecord[] = events.map((event) => ({
+    id: event.id,
+    title: event.title,
+    date: event.date as string,
+    description: event.description as string | null | undefined,
+    audience: Array.isArray(event.audience) ? (event.audience as string[]) : null,
+  }));
+
   return (
     <section className="space-y-6">
       <PageHeader title="Events" subtitle="Schedule school events and track important dates." />
-      <div className="card p-4 text-sm">Coming soon: calendar view and event list.</div>
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Events</h1>
+        <Link
+          href="/events/new"
+          className="rounded bg-black text-white px-3 py-1 text-sm hover:bg-black/80"
+        >
+          Schedule Event
+        </Link>
+      </header>
+      <EventListClient events={records} />
     </section>
   );
 }

--- a/src/app/financials/expenses/page.tsx
+++ b/src/app/financials/expenses/page.tsx
@@ -1,106 +1,265 @@
 import Link from "next/link";
+import Input from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
+import Badge from "@/components/ui/Badge";
 import { listFinancialEntries } from "../actions";
 
-export default async function ExpensesPage({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
+const categoryOptions = [
+  "salaries",
+  "benefits",
+  "training",
+  "utilities",
+  "maintenance",
+  "lab_equipment",
+  "software_license",
+  "learning_materials",
+  "tax",
+  "scholarship",
+  "miscellaneous",
+] as const;
+
+const statusOptions = ["paid", "outstanding", "waived"] as const;
+
+function formatLabel(value: string) {
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function statusTone(status?: string | null) {
+  switch (status) {
+    case "paid":
+      return "green" as const;
+    case "outstanding":
+      return "red" as const;
+    case "waived":
+      return "blue" as const;
+    default:
+      return "gray" as const;
+  }
+}
+
+export default async function ExpensesPage({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
   const category = (searchParams.category as string) || "";
+  const status = (searchParams.status as string) || "";
   const from = (searchParams.from as string) || "";
   const to = (searchParams.to as string) || "";
+
   const entries = await listFinancialEntries("expense", {
     category: category || undefined,
+    status: status || undefined,
     from: from || undefined,
     to: to || undefined,
   });
-  const total = entries.reduce((sum, e) => sum + Number(e.amount), 0);
-  const byCategory = entries.reduce<Record<string, number>>((acc, e) => {
-    acc[e.category as string] = (acc[e.category as string] || 0) + Number(e.amount);
+
+  const total = entries.reduce((sum, entry) => sum + Number(entry.amount || 0), 0);
+  const outstanding = entries
+    .filter((entry) => entry.status === "outstanding")
+    .reduce((sum, entry) => sum + Number(entry.amount || 0), 0);
+  const byCategory = entries.reduce<Record<string, number>>((acc, entry) => {
+    const key = entry.category as string;
+    acc[key] = (acc[key] || 0) + Number(entry.amount || 0);
     return acc;
   }, {});
+  const statusBreakdown = entries.reduce<Record<string, number>>((acc, entry) => {
+    const key = entry.status || "unassigned";
+    acc[key] = (acc[key] || 0) + Number(entry.amount || 0);
+    return acc;
+  }, {});
+  const outstandingTotal = statusBreakdown.outstanding ?? outstanding;
+
   return (
-    <section className="space-y-6">
-      <header className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Expenses</h1>
-        <div className="flex gap-2">
-          <Link href="/financials/expenses/export" className="rounded border px-3 py-1 text-sm">Export CSV</Link>
-          <Link href="/financials/expenses/new" className="rounded bg-black text-white px-3 py-1 text-sm">Add Expense</Link>
+    <section className="space-y-8">
+      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-[#0b0b0b]/70 p-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-white">Expense ledger</h1>
+          <p className="text-sm text-white/70">
+            Capture payroll, operations, and academic spend with clarity on obligations and approvals.
+          </p>
         </div>
-      </header>
-      <form method="GET" className="flex flex-wrap gap-2 text-sm">
-        <label className="flex items-center gap-2">
-          <span>Category</span>
-          <select name="category" defaultValue={category} className="border p-1 rounded">
-            <option value="">All</option>
-            {[
-              "salaries",
-              "benefits",
-              "training",
-              "utilities",
-              "maintenance",
-              "lab_equipment",
-              "software_license",
-              "learning_materials",
-              "tax",
-              "scholarship",
-              "miscellaneous",
-            ].map((c) => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
-        </label>
-        <label className="flex items-center gap-2">
-          <span>From</span>
-          <input name="from" type="date" defaultValue={from} className="border p-1 rounded" />
-        </label>
-        <label className="flex items-center gap-2">
-          <span>To</span>
-          <input name="to" type="date" defaultValue={to} className="border p-1 rounded" />
-        </label>
-        <button className="border rounded px-3 py-1">Filter</button>
-        <a className="border rounded px-3 py-1" href="/financials/expenses">Reset</a>
-      </form>
-      <div className="text-sm text-white/70">Total: {total.toLocaleString()}</div>
-      <div className="text-sm">
-        <div className="font-medium">By Category</div>
-        <div className="flex flex-wrap gap-3">
-          {Object.keys(byCategory).length === 0 ? (
-            <span className="text-gray-500">—</span>
-          ) : (
-            Object.entries(byCategory).map(([c, amt]) => (
-              <div key={c} className="border rounded px-2 py-1">{c}: {amt.toLocaleString()}</div>
-            ))
-          )}
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href="/financials/expenses/export"
+            className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/60"
+          >
+            Export CSV
+          </Link>
+          <Link
+            href="/financials/expenses/new"
+            className="inline-flex items-center justify-center rounded-full bg-[var(--brand)] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[var(--brand-500)]"
+          >
+            Log expense
+          </Link>
         </div>
       </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm border border-white/10">
-          <thead className="bg-[#0f172a] text-white/80">
-            <tr>
-              <th className="text-left p-2 border border-white/10">Date</th>
-              <th className="text-left p-2 border border-white/10">Category</th>
-              <th className="text-right p-2 border border-white/10">Amount</th>
-              <th className="text-left p-2 border border-white/10">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            {entries.length === 0 ? (
-              <tr>
-                <td className="p-2 border border-white/10 text-center" colSpan={4}>No entries</td>
-              </tr>
-            ) : entries.map((e) => (
-              <tr key={e.id}>
-                <td className="p-2 border border-white/10">{e.date}</td>
-                <td className="p-2 border border-white/10">{e.category}</td>
-                <td className="p-2 border border-white/10 text-right">{Number(e.amount).toLocaleString()}</td>
-                <td className="p-2 border border-white/10">{e.description || "—"}</td>
-              </tr>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[{
+          label: "Total spend",
+          value: total.toLocaleString(),
+          detail: "Filtered timeframe",
+        },
+        {
+          label: "Outstanding",
+          value: outstandingTotal.toLocaleString(),
+          detail: "Awaiting disbursement",
+        },
+        {
+          label: "Records",
+          value: entries.length.toLocaleString(),
+          detail: "Expense lines",
+        },
+        {
+          label: "Statuses",
+          value: Object.keys(statusBreakdown).length.toLocaleString(),
+          detail: "Distribution mix",
+        }].map((card) => (
+          <div
+            key={card.label}
+            className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/5 via-transparent to-white/5 p-5"
+          >
+            <p className="text-xs uppercase tracking-[0.28em] text-white/45">{card.label}</p>
+            <p className="mt-3 text-2xl font-semibold text-white">{card.value}</p>
+            <p className="mt-2 text-sm text-white/60">{card.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      <form method="GET" className="glass flex flex-wrap items-end gap-3 rounded-3xl border border-white/10 p-5 text-sm">
+        <div className="flex min-w-[200px] flex-col gap-1">
+          <label className="text-xs uppercase tracking-[0.24em] text-white/45">Category</label>
+          <Select name="category" defaultValue={category}>
+            <option value="">All categories</option>
+            {categoryOptions.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
             ))}
-          </tbody>
-        </table>
+          </Select>
+        </div>
+        <div className="flex min-w-[160px] flex-col gap-1">
+          <label className="text-xs uppercase tracking-[0.24em] text-white/45">Status</label>
+          <Select name="status" defaultValue={status}>
+            <option value="">All statuses</option>
+            {statusOptions.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="flex min-w-[160px] flex-col gap-1">
+          <label className="text-xs uppercase tracking-[0.24em] text-white/45">From</label>
+          <Input name="from" type="date" defaultValue={from} />
+        </div>
+        <div className="flex min-w-[160px] flex-col gap-1">
+          <label className="text-xs uppercase tracking-[0.24em] text-white/45">To</label>
+          <Input name="to" type="date" defaultValue={to} />
+        </div>
+        <div className="ml-auto flex gap-2">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-black transition hover:bg-white/90"
+          >
+            Apply filters
+          </button>
+          <a
+            href="/financials/expenses"
+            className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/60"
+          >
+            Reset
+          </a>
+        </div>
+      </form>
+
+      <div className="grid gap-4 lg:grid-cols-[1.2fr,0.8fr]">
+        <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+          <div className="flex items-center justify-between">
+            <h2 className="font-display text-lg font-semibold text-white">Expense register</h2>
+            <span className="text-xs uppercase tracking-[0.28em] text-white/45">{entries.length} entries</span>
+          </div>
+          <div className="mt-4 overflow-hidden rounded-2xl border border-white/10">
+            <table className="min-w-full divide-y divide-white/10 text-sm">
+              <thead className="bg-white/5 text-xs uppercase tracking-[0.28em] text-white/50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium">Date</th>
+                  <th className="px-4 py-3 text-left font-medium">Category</th>
+                  <th className="px-4 py-3 text-left font-medium">Description</th>
+                  <th className="px-4 py-3 text-right font-medium">Amount</th>
+                  <th className="px-4 py-3 text-left font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10 text-white/80">
+                {entries.length === 0 ? (
+                  <tr>
+                    <td className="px-4 py-6 text-center text-sm text-white/60" colSpan={5}>
+                      No expense entries match these filters yet.
+                    </td>
+                  </tr>
+                ) : (
+                  entries.map((entry) => (
+                    <tr key={entry.id} className="hover:bg-white/5">
+                      <td className="px-4 py-3">{entry.date}</td>
+                      <td className="px-4 py-3 capitalize">{formatLabel(entry.category as string)}</td>
+                      <td className="px-4 py-3 text-white/70">{entry.description || "—"}</td>
+                      <td className="px-4 py-3 text-right font-medium text-white">
+                        {Number(entry.amount).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge color={statusTone(entry.status)}>{entry.status || "—"}</Badge>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+            <h3 className="font-display text-lg font-semibold text-white">Category mix</h3>
+            <ul className="mt-4 space-y-3 text-sm text-white/80">
+              {Object.keys(byCategory).length === 0 ? (
+                <li className="text-white/60">No expenses recorded.</li>
+              ) : (
+                Object.entries(byCategory)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([key, value]) => (
+                    <li key={key} className="flex items-center justify-between">
+                      <span className="capitalize">{formatLabel(key)}</span>
+                      <span className="rounded-full border border-rose-500/30 bg-rose-500/10 px-3 py-1 text-sm text-rose-100">
+                        {value.toLocaleString()}
+                      </span>
+                    </li>
+                  ))
+              )}
+            </ul>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+            <h3 className="font-display text-lg font-semibold text-white">Status spotlight</h3>
+            <ul className="mt-4 space-y-3 text-sm text-white/80">
+              {Object.keys(statusBreakdown).length === 0 ? (
+                <li className="text-white/60">No statuses recorded.</li>
+              ) : (
+                Object.entries(statusBreakdown)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([key, value]) => (
+                    <li key={key} className="flex items-center justify-between">
+                      <span className="capitalize">{formatLabel(key)}</span>
+                      <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-sm text-white">
+                        {value.toLocaleString()}
+                      </span>
+                    </li>
+                  ))
+              )}
+            </ul>
+          </div>
+        </div>
       </div>
     </section>
   );
 }
-
-
-
-
-

--- a/src/app/financials/income/page.tsx
+++ b/src/app/financials/income/page.tsx
@@ -1,115 +1,261 @@
 import Link from "next/link";
+import Input from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
+import Badge from "@/components/ui/Badge";
 import { listFinancialEntries } from "../actions";
 
-export default async function IncomePage({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
+const categoryOptions = [
+  "fees",
+  "dues",
+  "medical",
+  "sanctions",
+  "grants",
+  "donations",
+  "trade_fare",
+] as const;
+
+const statusOptions = ["paid", "outstanding", "waived"] as const;
+
+function formatLabel(value: string) {
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function statusTone(status?: string | null) {
+  switch (status) {
+    case "paid":
+      return "green" as const;
+    case "outstanding":
+      return "red" as const;
+    case "waived":
+      return "blue" as const;
+    default:
+      return "gray" as const;
+  }
+}
+
+export default async function IncomePage({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
   const category = (searchParams.category as string) || "";
   const status = (searchParams.status as string) || "";
   const from = (searchParams.from as string) || "";
   const to = (searchParams.to as string) || "";
+
   const entries = await listFinancialEntries("income", {
     category: category || undefined,
     status: status || undefined,
     from: from || undefined,
     to: to || undefined,
   });
-  const total = entries.reduce((sum, e) => sum + Number(e.amount), 0);
-  const byCategory = entries.reduce<Record<string, number>>((acc, e) => {
-    acc[e.category as string] = (acc[e.category as string] || 0) + Number(e.amount);
+
+  const total = entries.reduce((sum, entry) => sum + Number(entry.amount || 0), 0);
+  const outstanding = entries
+    .filter((entry) => entry.status === "outstanding")
+    .reduce((sum, entry) => sum + Number(entry.amount || 0), 0);
+  const byCategory = entries.reduce<Record<string, number>>((acc, entry) => {
+    const key = entry.category as string;
+    acc[key] = (acc[key] || 0) + Number(entry.amount || 0);
     return acc;
   }, {});
+  const statusBreakdown = entries.reduce<Record<string, number>>((acc, entry) => {
+    const key = entry.status || "unassigned";
+    acc[key] = (acc[key] || 0) + Number(entry.amount || 0);
+    return acc;
+  }, {});
+  const outstandingTotal = statusBreakdown.outstanding ?? outstanding;
+
   return (
-    <section className="space-y-6">
-      <header className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Income</h1>
-        <div className="flex gap-2">
-          <Link href="/financials/income/export" className="rounded border px-3 py-1 text-sm">Export CSV</Link>
-          <Link href="/financials/income/new" className="rounded bg-black text-white px-3 py-1 text-sm">Add Income</Link>
+    <section className="space-y-8">
+      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-[#0b0b0b]/70 p-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-white">Income ledger</h1>
+          <p className="text-sm text-white/70">
+            Track every inflow from tuition to grants, reconcile statuses, and surface outstanding balances instantly.
+          </p>
         </div>
-      </header>
-      <form method="GET" className="flex flex-wrap gap-2 text-sm">
-        <label className="flex items-center gap-2">
-          <span>Category</span>
-          <select name="category" defaultValue={category} className="border p-1 rounded">
-            <option value="">All</option>
-            {[
-              "fees",
-              "dues",
-              "medical",
-              "sanctions",
-              "grants",
-              "donations",
-              "trade_fare",
-            ].map((c) => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
-        </label>
-        <label className="flex items-center gap-2">
-          <span>Status</span>
-          <select name="status" defaultValue={status} className="border p-1 rounded">
-            <option value="">All</option>
-            <option value="paid">paid</option>
-            <option value="outstanding">outstanding</option>
-            <option value="waived">waived</option>
-          </select>
-        </label>
-        <label className="flex items-center gap-2">
-          <span>From</span>
-          <input name="from" type="date" defaultValue={from} className="border p-1 rounded" />
-        </label>
-        <label className="flex items-center gap-2">
-          <span>To</span>
-          <input name="to" type="date" defaultValue={to} className="border p-1 rounded" />
-        </label>
-        <button className="border rounded px-3 py-1">Filter</button>
-        <a className="border rounded px-3 py-1" href="/financials/income">Reset</a>
-      </form>
-      <div className="text-sm text-white/70">Total: {total.toLocaleString()}</div>
-      <div className="text-sm">
-        <div className="font-medium">By Category</div>
-        <div className="flex flex-wrap gap-3">
-          {Object.keys(byCategory).length === 0 ? (
-            <span className="text-gray-500">—</span>
-          ) : (
-            Object.entries(byCategory).map(([c, amt]) => (
-              <div key={c} className="border rounded px-2 py-1">{c}: {amt.toLocaleString()}</div>
-            ))
-          )}
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href="/financials/income/export"
+            className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/60"
+          >
+            Export CSV
+          </Link>
+          <Link
+            href="/financials/income/new"
+            className="inline-flex items-center justify-center rounded-full bg-[var(--brand)] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[var(--brand-500)]"
+          >
+            Log income
+          </Link>
         </div>
       </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm border border-white/10">
-          <thead className="bg-[#0f172a] text-white/80">
-            <tr>
-              <th className="text-left p-2 border border-white/10">Date</th>
-              <th className="text-left p-2 border border-white/10">Category</th>
-              <th className="text-right p-2 border border-white/10">Amount</th>
-              <th className="text-left p-2 border border-white/10">Description</th>
-              <th className="text-left p-2 border border-white/10">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {entries.length === 0 ? (
-              <tr>
-                <td className="p-2 border border-white/10 text-center" colSpan={5}>No entries</td>
-              </tr>
-            ) : entries.map((e) => (
-              <tr key={e.id}>
-                <td className="p-2 border border-white/10">{e.date}</td>
-                <td className="p-2 border border-white/10">{e.category}</td>
-                <td className="p-2 border border-white/10 text-right">{Number(e.amount).toLocaleString()}</td>
-                <td className="p-2 border border-white/10">{e.description || "—"}</td>
-                <td className="p-2 border border-white/10">{e.status || "—"}</td>
-              </tr>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[{
+          label: "Total income",
+          value: total.toLocaleString(),
+          detail: "Filtered timeframe",
+        },
+        {
+          label: "Outstanding",
+          value: outstandingTotal.toLocaleString(),
+          detail: "Awaiting settlement",
+        },
+        {
+          label: "Records",
+          value: entries.length.toLocaleString(),
+          detail: "Entries returned",
+        },
+        {
+          label: "Statuses",
+          value: Object.keys(statusBreakdown).length.toLocaleString(),
+          detail: "Distribution mix",
+        }].map((card) => (
+          <div
+            key={card.label}
+            className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/5 via-transparent to-white/5 p-5"
+          >
+            <p className="text-xs uppercase tracking-[0.28em] text-white/45">{card.label}</p>
+            <p className="mt-3 text-2xl font-semibold text-white">{card.value}</p>
+            <p className="mt-2 text-sm text-white/60">{card.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      <form method="GET" className="glass flex flex-wrap items-end gap-3 rounded-3xl border border-white/10 p-5 text-sm">
+        <div className="flex min-w-[180px] flex-col gap-1">
+          <label className="text-xs uppercase tracking-[0.24em] text-white/45">Category</label>
+          <Select name="category" defaultValue={category}>
+            <option value="">All categories</option>
+            {categoryOptions.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
             ))}
-          </tbody>
-        </table>
+          </Select>
+        </div>
+        <div className="flex min-w-[160px] flex-col gap-1">
+          <label className="text-xs uppercase tracking-[0.24em] text-white/45">Status</label>
+          <Select name="status" defaultValue={status}>
+            <option value="">All statuses</option>
+            {statusOptions.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="flex min-w-[160px] flex-col gap-1">
+          <label className="text-xs uppercase tracking-[0.24em] text-white/45">From</label>
+          <Input name="from" type="date" defaultValue={from} />
+        </div>
+        <div className="flex min-w-[160px] flex-col gap-1">
+          <label className="text-xs uppercase tracking-[0.24em] text-white/45">To</label>
+          <Input name="to" type="date" defaultValue={to} />
+        </div>
+        <div className="ml-auto flex gap-2">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-black transition hover:bg-white/90"
+          >
+            Apply filters
+          </button>
+          <a
+            href="/financials/income"
+            className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/60"
+          >
+            Reset
+          </a>
+        </div>
+      </form>
+
+      <div className="grid gap-4 lg:grid-cols-[1.2fr,0.8fr]">
+        <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+          <div className="flex items-center justify-between">
+            <h2 className="font-display text-lg font-semibold text-white">Income timeline</h2>
+            <span className="text-xs uppercase tracking-[0.28em] text-white/45">{entries.length} entries</span>
+          </div>
+          <div className="mt-4 overflow-hidden rounded-2xl border border-white/10">
+            <table className="min-w-full divide-y divide-white/10 text-sm">
+              <thead className="bg-white/5 text-xs uppercase tracking-[0.28em] text-white/50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium">Date</th>
+                  <th className="px-4 py-3 text-left font-medium">Category</th>
+                  <th className="px-4 py-3 text-left font-medium">Description</th>
+                  <th className="px-4 py-3 text-right font-medium">Amount</th>
+                  <th className="px-4 py-3 text-left font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10 text-white/80">
+                {entries.length === 0 ? (
+                  <tr>
+                    <td className="px-4 py-6 text-center text-sm text-white/60" colSpan={5}>
+                      No income entries match these filters yet.
+                    </td>
+                  </tr>
+                ) : (
+                  entries.map((entry) => (
+                    <tr key={entry.id} className="hover:bg-white/5">
+                      <td className="px-4 py-3">{entry.date}</td>
+                      <td className="px-4 py-3 capitalize">{formatLabel(entry.category as string)}</td>
+                      <td className="px-4 py-3 text-white/70">{entry.description || "—"}</td>
+                      <td className="px-4 py-3 text-right font-medium text-white">
+                        {Number(entry.amount).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge color={statusTone(entry.status)}>{entry.status || "—"}</Badge>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+            <h3 className="font-display text-lg font-semibold text-white">Category mix</h3>
+            <ul className="mt-4 space-y-3 text-sm text-white/80">
+              {Object.keys(byCategory).length === 0 ? (
+                <li className="text-white/60">No income recorded.</li>
+              ) : (
+                Object.entries(byCategory)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([key, value]) => (
+                    <li key={key} className="flex items-center justify-between">
+                      <span className="capitalize">{formatLabel(key)}</span>
+                      <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-sm text-emerald-100">
+                        {value.toLocaleString()}
+                      </span>
+                    </li>
+                  ))
+              )}
+            </ul>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+            <h3 className="font-display text-lg font-semibold text-white">Status spotlight</h3>
+            <ul className="mt-4 space-y-3 text-sm text-white/80">
+              {Object.keys(statusBreakdown).length === 0 ? (
+                <li className="text-white/60">No statuses recorded.</li>
+              ) : (
+                Object.entries(statusBreakdown)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([key, value]) => (
+                    <li key={key} className="flex items-center justify-between">
+                      <span className="capitalize">{formatLabel(key)}</span>
+                      <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-sm text-white">
+                        {value.toLocaleString()}
+                      </span>
+                    </li>
+                  ))
+              )}
+            </ul>
+          </div>
+        </div>
       </div>
     </section>
   );
 }
-
-
-
-
-

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -1,20 +1,179 @@
 import Link from "next/link";
 import PageHeader from "@/components/PageHeader";
+import { listFinancialEntries } from "./actions";
 
-export default function FinancialsPage() {
+type FinancialEntry = {
+  amount: number;
+  category: string;
+  status?: string | null;
+};
+
+type Summary = {
+  total: number;
+  outstanding: number;
+  byCategory: Record<string, number>;
+};
+
+function summarise(entries: FinancialEntry[]): Summary {
+  const total = entries.reduce((sum, entry) => sum + Number(entry.amount || 0), 0);
+  const outstanding = entries
+    .filter((entry) => entry.status === "outstanding")
+    .reduce((sum, entry) => sum + Number(entry.amount || 0), 0);
+  const byCategory = entries.reduce<Record<string, number>>((acc, entry) => {
+    const key = entry.category;
+    acc[key] = (acc[key] || 0) + Number(entry.amount || 0);
+    return acc;
+  }, {});
+  return { total, outstanding, byCategory };
+}
+
+export default async function FinancialsPage() {
+  const [incomeEntries, expenseEntries] = await Promise.all([
+    listFinancialEntries("income"),
+    listFinancialEntries("expense"),
+  ]);
+
+  const incomeSummary = summarise(incomeEntries as unknown as FinancialEntry[]);
+  const expenseSummary = summarise(expenseEntries as unknown as FinancialEntry[]);
+  const netPosition = incomeSummary.total - expenseSummary.total;
+  const receivables = incomeEntries.filter((entry) => entry.status === "outstanding");
+  const payables = expenseEntries.filter((entry) => entry.status === "outstanding");
+  const topIncomeCategories = Object.entries(incomeSummary.byCategory)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
+  const topExpenseCategories = Object.entries(expenseSummary.byCategory)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
+
   return (
-    <section className="space-y-6">
-      <PageHeader title="Financials" subtitle="Manage income and expenses, and generate reports." />
-      <h1 className="text-xl font-semibold">Financials</h1>
-      <p className="text-sm text-white/70">
-        Manage fees, dues, medicals, sanctions, income sources and expenses.
-      </p>
-      <div className="flex gap-4 text-sm">
-        <Link href="/financials/income" className="rounded border px-3 py-2">Income</Link>
-        <Link href="/financials/expenses" className="rounded border px-3 py-2">Expenses</Link>
+    <section className="space-y-8">
+      <PageHeader
+        title="Financials"
+        subtitle="See revenue, dues, sanctions, and operating spend in one matte-black command centre."
+      />
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[{
+          label: "Total income",
+          value: incomeSummary.total.toLocaleString(),
+          detail: "Fees, dues, grants, and more",
+        },
+        {
+          label: "Total expenses",
+          value: expenseSummary.total.toLocaleString(),
+          detail: "Salaries, maintenance, licences",
+        },
+        {
+          label: "Net position",
+          value: netPosition.toLocaleString(),
+          detail: netPosition >= 0 ? "Surplus" : "Deficit",
+        },
+        {
+          label: "Outstanding receivables",
+          value: incomeSummary.outstanding.toLocaleString(),
+          detail: `${receivables.length} awaiting settlement`,
+        }].map((card) => (
+          <div
+            key={card.label}
+            className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/5 via-transparent to-white/5 p-5"
+          >
+            <p className="text-xs uppercase tracking-[0.28em] text-white/45">{card.label}</p>
+            <p className="mt-3 text-2xl font-semibold text-white">{card.value}</p>
+            <p className="mt-2 text-sm text-white/60">{card.detail}</p>
+          </div>
+        ))}
       </div>
-      <div className="border p-4 rounded text-sm">Overview: Coming soon</div>
+      <div className="grid gap-4 lg:grid-cols-[1.1fr,0.9fr]">
+        <div className="rounded-3xl border border-white/10 bg-[#0b0b0b]/70 p-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="font-display text-lg font-semibold text-white">Financial nerve centre</h2>
+              <p className="text-sm text-white/70">
+                Monitor working capital, reconcile receipts, and trigger financial statements without leaving the dashboard.
+              </p>
+            </div>
+            <Link
+              href="/financials/report"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-white transition hover:border-white/60"
+            >
+              Generate report
+            </Link>
+          </div>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            <div className="rounded-2xl border border-white/10 bg-black/40 p-5">
+              <p className="text-xs uppercase tracking-[0.28em] text-white/45">Receivables</p>
+              <p className="mt-2 text-2xl font-semibold text-white">{incomeSummary.outstanding.toLocaleString()}</p>
+              <p className="mt-1 text-sm text-white/60">{receivables.length} inflows pending settlement.</p>
+              <Link
+                href="/financials/income?status=outstanding"
+                className="mt-4 inline-flex items-center gap-2 text-sm text-[var(--brand-200)] hover:text-[var(--brand)]"
+              >
+                Review outstanding ↗
+              </Link>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-black/40 p-5">
+              <p className="text-xs uppercase tracking-[0.28em] text-white/45">Payables</p>
+              <p className="mt-2 text-2xl font-semibold text-white">
+                {payables.reduce((sum, entry) => sum + Number(entry.amount || 0), 0).toLocaleString()}
+              </p>
+              <p className="mt-1 text-sm text-white/60">{payables.length} expense obligations queued.</p>
+              <Link
+                href="/financials/expenses?status=outstanding"
+                className="mt-4 inline-flex items-center gap-2 text-sm text-[var(--brand-200)] hover:text-[var(--brand)]"
+              >
+                View pending payouts ↗
+              </Link>
+            </div>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+            <h3 className="font-display text-lg font-semibold text-white">Income composition</h3>
+            <ul className="mt-4 space-y-3 text-sm text-white/80">
+              {topIncomeCategories.length === 0 ? (
+                <li className="text-white/60">No income recorded yet.</li>
+              ) : (
+                topIncomeCategories.map(([category, amount]) => (
+                  <li key={`income-${category}`} className="flex items-center justify-between">
+                    <span className="capitalize">{category.replace(/_/g, " ")}</span>
+                    <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-sm text-emerald-100">
+                      {amount.toLocaleString()}
+                    </span>
+                  </li>
+                ))
+              )}
+            </ul>
+            <Link
+              href="/financials/income"
+              className="mt-4 inline-flex items-center gap-2 text-sm text-[var(--brand-200)] hover:text-[var(--brand)]"
+            >
+              Manage income ↗
+            </Link>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+            <h3 className="font-display text-lg font-semibold text-white">Expense composition</h3>
+            <ul className="mt-4 space-y-3 text-sm text-white/80">
+              {topExpenseCategories.length === 0 ? (
+                <li className="text-white/60">No expenses recorded yet.</li>
+              ) : (
+                topExpenseCategories.map(([category, amount]) => (
+                  <li key={`expense-${category}`} className="flex items-center justify-between">
+                    <span className="capitalize">{category.replace(/_/g, " ")}</span>
+                    <span className="rounded-full border border-rose-500/30 bg-rose-500/10 px-3 py-1 text-sm text-rose-100">
+                      {amount.toLocaleString()}
+                    </span>
+                  </li>
+                ))
+              )}
+            </ul>
+            <Link
+              href="/financials/expenses"
+              className="mt-4 inline-flex items-center gap-2 text-sm text-[var(--brand-200)] hover:text-[var(--brand)]"
+            >
+              Manage expenses ↗
+            </Link>
+          </div>
+        </div>
+      </div>
     </section>
   );
 }
-

--- a/src/app/performance/page.tsx
+++ b/src/app/performance/page.tsx
@@ -1,62 +1,172 @@
-import Link from "next/link";
 import { listAcademicRecords, performanceDashboard } from "./actions";
 import PageHeader from "@/components/PageHeader";
+import Link from "next/link";
 
 export default async function PerformancePage() {
   const [stats, records] = await Promise.all([
     performanceDashboard(),
     listAcademicRecords(),
   ]);
+  const byTerm = records.reduce<Record<string, { count: number; avgCgpa: number; avgAttendance: number }>>((acc, record) => {
+    const entry = acc[record.term] ?? { count: 0, avgCgpa: 0, avgAttendance: 0 };
+    entry.count += 1;
+    entry.avgCgpa += record.cgpa ?? 0;
+    entry.avgAttendance += record.attendance ?? 0;
+    acc[record.term] = entry;
+    return acc;
+  }, {});
+  const termInsights = Object.entries(byTerm).map(([term, value]) => ({
+    term,
+    avgCgpa: value.count ? value.avgCgpa / value.count : 0,
+    avgAttendance: value.count ? value.avgAttendance / value.count : 0,
+    count: value.count,
+  }));
+  const bestTerm = termInsights.sort((a, b) => (b.avgCgpa || 0) - (a.avgCgpa || 0))[0];
+  const topAttendance = records
+    .filter((record) => record.attendance != null)
+    .sort((a, b) => (b.attendance ?? 0) - (a.attendance ?? 0))
+    .slice(0, 3);
+  const topCgpa = records
+    .filter((record) => record.cgpa != null)
+    .sort((a, b) => (b.cgpa ?? 0) - (a.cgpa ?? 0))
+    .slice(0, 3);
   return (
-    <section className="space-y-6">
-      <PageHeader title="Performance" subtitle="Track attendance, assessments, and CGPA across terms." />
-      <header className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Performance</h1>
-        <Link href="/performance/new" className="rounded bg-black text-white px-3 py-1 text-sm">Add Record</Link>
-      </header>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
-        <div className="border rounded p-4">
-          <div className="text-gray-500">Records</div>
-          <div className="text-xl font-semibold">{stats.count}</div>
-        </div>
-        <div className="border rounded p-4">
-          <div className="text-gray-500">Avg Attendance</div>
-          <div className="text-xl font-semibold">{stats.avgAttendance.toFixed(1)}%</div>
-        </div>
-        <div className="border rounded p-4">
-          <div className="text-gray-500">Avg CGPA</div>
-          <div className="text-xl font-semibold">{stats.avgCgpa.toFixed(2)}</div>
-        </div>
+    <section className="space-y-8">
+      <PageHeader
+        title="Performance"
+        subtitle="Blend attendance, assessments, and CGPA to surface where intervention or celebration is required."
+      />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[{
+          label: "Recorded entries",
+          value: stats.count.toLocaleString(),
+          detail: "Assessments captured",
+        },
+        {
+          label: "Average attendance",
+          value: `${stats.avgAttendance.toFixed(1)}%`,
+          detail: "Across all submissions",
+        },
+        {
+          label: "Average CGPA",
+          value: stats.avgCgpa.toFixed(2),
+          detail: "Current academic pulse",
+        },
+        {
+          label: "Best performing term",
+          value: bestTerm ? bestTerm.term : "—",
+          detail: bestTerm
+            ? `${bestTerm.avgCgpa.toFixed(2)} CGPA · ${bestTerm.avgAttendance.toFixed(0)}% attendance`
+            : "Awaiting records",
+        }].map((card) => (
+          <div
+            key={card.label}
+            className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/5 via-transparent to-white/5 p-5"
+          >
+            <p className="text-xs uppercase tracking-[0.28em] text-white/45">{card.label}</p>
+            <p className="mt-3 text-2xl font-semibold text-white">{card.value}</p>
+            <p className="mt-2 text-sm text-white/60">{card.detail}</p>
+          </div>
+        ))}
       </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm border">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="text-left p-2 border">Student</th>
-              <th className="text-left p-2 border">Term</th>
-              <th className="text-left p-2 border">Attendance</th>
-              <th className="text-left p-2 border">Grade</th>
-              <th className="text-left p-2 border">CGPA</th>
-            </tr>
-          </thead>
-          <tbody>
-            {records.length === 0 ? (
-              <tr>
-                <td className="p-2 border text-center" colSpan={5}>No records yet</td>
-              </tr>
-            ) : (
-              records.map((r) => (
-                <tr key={r.id}>
-                  <td className="p-2 border">{(r as any).student?.name || r.studentId}</td>
-                  <td className="p-2 border">{r.term}</td>
-                  <td className="p-2 border">{r.attendance ?? "—"}</td>
-                  <td className="p-2 border">{r.grade ?? "—"}</td>
-                  <td className="p-2 border">{r.cgpa ?? "—"}</td>
+      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-[#0b0b0b]/70 p-5 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-display text-lg font-semibold text-white">Academic performance cockpit</h2>
+          <p className="text-sm text-white/70">
+            Drill into top achievers, attendance anomalies, and grade distributions across sessions and terms.
+          </p>
+        </div>
+        <Link
+          href="/performance/new"
+          className="inline-flex items-center justify-center rounded-full bg-[var(--brand)] px-5 py-2 text-sm font-semibold text-white transition hover:bg-[var(--brand-500)]"
+        >
+          Log assessment
+        </Link>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-[1.2fr,1fr]">
+        <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="font-display text-lg font-semibold text-white">Latest records</h3>
+            <span className="text-xs uppercase tracking-[0.28em] text-white/45">Term snapshots</span>
+          </div>
+          <div className="mt-4 overflow-hidden rounded-2xl border border-white/10">
+            <table className="min-w-full divide-y divide-white/10 text-sm">
+              <thead className="bg-white/5 text-xs uppercase tracking-[0.28em] text-white/50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium">Student</th>
+                  <th className="px-4 py-3 text-left font-medium">Term</th>
+                  <th className="px-4 py-3 text-left font-medium">Attendance</th>
+                  <th className="px-4 py-3 text-left font-medium">Grade</th>
+                  <th className="px-4 py-3 text-left font-medium">CGPA</th>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+              </thead>
+              <tbody className="divide-y divide-white/10 text-white/80">
+                {records.length === 0 ? (
+                  <tr>
+                    <td className="px-4 py-6 text-center text-sm text-white/60" colSpan={5}>
+                      No records yet. Start logging assessments to unlock performance analytics.
+                    </td>
+                  </tr>
+                ) : (
+                  records.map((record) => (
+                    <tr key={record.id} className="hover:bg-white/5">
+                      <td className="px-4 py-3">
+                        <div className="font-medium text-white">{(record as any).student?.name || record.studentId}</div>
+                        <div className="text-xs text-white/60">ID: {record.studentId}</div>
+                      </td>
+                      <td className="px-4 py-3">{record.term}</td>
+                      <td className="px-4 py-3">{record.attendance != null ? `${record.attendance.toFixed(1)}%` : "—"}</td>
+                      <td className="px-4 py-3">{record.grade ?? "—"}</td>
+                      <td className="px-4 py-3">{record.cgpa != null ? record.cgpa.toFixed(2) : "—"}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+            <h3 className="font-display text-lg font-semibold text-white">Top attendance</h3>
+            <ul className="mt-4 space-y-3 text-sm text-white/80">
+              {topAttendance.length === 0 ? (
+                <li className="text-white/60">Awaiting submissions</li>
+              ) : (
+                topAttendance.map((record) => (
+                  <li key={`attendance-${record.id}`} className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium text-white">{(record as any).student?.name || record.studentId}</div>
+                      <div className="text-xs text-white/60">{record.term}</div>
+                    </div>
+                    <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-sm text-emerald-100">
+                      {record.attendance?.toFixed(1)}%
+                    </span>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-black/40 p-6">
+            <h3 className="font-display text-lg font-semibold text-white">Highest CGPA</h3>
+            <ul className="mt-4 space-y-3 text-sm text-white/80">
+              {topCgpa.length === 0 ? (
+                <li className="text-white/60">Awaiting results</li>
+              ) : (
+                topCgpa.map((record) => (
+                  <li key={`cgpa-${record.id}`} className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium text-white">{(record as any).student?.name || record.studentId}</div>
+                      <div className="text-xs text-white/60">{record.term}</div>
+                    </div>
+                    <span className="rounded-full border border-sky-500/30 bg-sky-500/10 px-3 py-1 text-sm text-sky-100">
+                      {record.cgpa?.toFixed(2)}
+                    </span>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/src/app/staff/page.tsx
+++ b/src/app/staff/page.tsx
@@ -5,21 +5,67 @@ import PageHeader from "@/components/PageHeader";
 
 export default async function StaffPage() {
   const staff = await listStaff();
+  const total = staff.length;
+  const active = staff.filter((member) => member.status === "active").length;
+  const academic = staff.filter((member) => member.role === "academic").length;
+  const payroll = staff.reduce((sum, member) => sum + (Number(member.salary) || 0), 0);
+  const sanctions = staff.filter((member) => Boolean(member.sanction)).length;
   return (
-    <section className="space-y-6">
-      <PageHeader title="Staff" subtitle="Manage staff biodata, roles, ranks, and salaries." />
-      <header className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Staff</h1>
+    <section className="space-y-8">
+      <PageHeader
+        title="Staff"
+        subtitle="Track faculty credentials, compensation, and welfare markers across academic and administrative teams."
+      />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[{
+          label: "Total staff",
+          value: total.toLocaleString(),
+          detail: "Institution-wide",
+        },
+        {
+          label: "Active",
+          value: active.toLocaleString(),
+          detail: "On payroll today",
+        },
+        {
+          label: "Academic faculty",
+          value: academic.toLocaleString(),
+          detail: "Teaching & research",
+        },
+        {
+          label: "Payroll (monthly)",
+          value: payroll ? payroll.toLocaleString() : "—",
+          detail: "Sum of recorded salaries",
+        }].map((card) => (
+          <div
+            key={card.label}
+            className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/5 via-transparent to-white/5 p-5"
+          >
+            <p className="text-xs uppercase tracking-[0.28em] text-white/45">{card.label}</p>
+            <p className="mt-3 text-2xl font-semibold text-white">{card.value}</p>
+            <p className="mt-2 text-sm text-white/60">{card.detail}</p>
+          </div>
+        ))}
+      </div>
+      {sanctions ? (
+        <div className="rounded-3xl border border-rose-500/25 bg-rose-500/10 p-4 text-sm text-rose-100">
+          {sanctions} staff member{sanctions === 1 ? "" : "s"} have open sanctions requiring follow-up.
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-[#0b0b0b]/70 p-5 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-display text-lg font-semibold text-white">Faculty & operations roster</h2>
+          <p className="text-sm text-white/70">
+            Segment by status, spotlight qualifications, and ensure payroll data aligns before each salary run.
+          </p>
+        </div>
         <Link
           href="/staff/new"
-          className="rounded bg-black text-white px-3 py-1 text-sm"
+          className="inline-flex items-center justify-center rounded-full bg-[var(--brand)] px-5 py-2 text-sm font-semibold text-white transition hover:bg-[var(--brand-500)]"
         >
-          Add Staff
+          Add staff record
         </Link>
-      </header>
-      <p className="text-sm text-white/70">
-        Record and manage staff biodata, ranks, roles, and salaries.
-      </p>
+      </div>
       <StaffListClient staff={staff as any} />
     </section>
   );

--- a/src/app/students/page.tsx
+++ b/src/app/students/page.tsx
@@ -5,18 +5,69 @@ import PageHeader from "@/components/PageHeader";
 
 export default async function StudentsPage() {
   const students = await listStudents();
+  const total = students.length;
+  const active = students.filter((student) => student.status === "active").length;
+  const scholarships = students.filter((student) => Boolean(student.scholarship)).length;
+  const sanctions = students.filter((student) => Boolean(student.sanction)).length;
+  const averageCgpa = total
+    ? students.reduce((sum, student) => sum + (Number(student.cgpa) || 0), 0) / total
+    : 0;
   return (
-    <section className="space-y-6">
-      <PageHeader title="Students" subtitle="Record and manage student biodata, academics, and finances." />
-      <header className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Students</h1>
+    <section className="space-y-8">
+      <PageHeader
+        title="Students"
+        subtitle="A refined directory covering biodata, guardians, scholarships, academics, and wellbeing signals."
+      />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[{
+          label: "Total learners",
+          value: total.toLocaleString(),
+          detail: "Across all programmes",
+        },
+        {
+          label: "Active",
+          value: active.toLocaleString(),
+          detail: "Currently enrolled",
+        },
+        {
+          label: "Scholarships",
+          value: scholarships.toLocaleString(),
+          detail: "Awarded financial aid",
+        },
+        {
+          label: "Average CGPA",
+          value: averageCgpa ? averageCgpa.toFixed(2) : "—",
+          detail: "Across recorded results",
+        }].map((card) => (
+          <div
+            key={card.label}
+            className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/5 via-transparent to-white/5 p-5"
+          >
+            <p className="text-xs uppercase tracking-[0.28em] text-white/45">{card.label}</p>
+            <p className="mt-3 text-2xl font-semibold text-white">{card.value}</p>
+            <p className="mt-2 text-sm text-white/60">{card.detail}</p>
+          </div>
+        ))}
+      </div>
+      {sanctions ? (
+        <div className="rounded-3xl border border-rose-500/25 bg-rose-500/10 p-4 text-sm text-rose-100">
+          {sanctions} student{sanctions === 1 ? "" : "s"} currently have active sanctions logged.
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-[#0b0b0b]/70 p-5 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-display text-lg font-semibold text-white">Learner registry</h2>
+          <p className="text-sm text-white/70">
+            Filter by status, highlight scholarships, and surface wellbeing considerations before parent-teacher meetings.
+          </p>
+        </div>
         <Link
           href="/students/new"
-          className="rounded bg-black text-white px-3 py-1 text-sm"
+          className="inline-flex items-center justify-center rounded-full bg-[var(--brand)] px-5 py-2 text-sm font-semibold text-white transition hover:bg-[var(--brand-500)]"
         >
-          Add Student
+          Add student record
         </Link>
-      </header>
+      </div>
       <StudentListClient students={students as any} />
     </section>
   );

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useActionState } from "react";
+import { useRouter } from "next/navigation";
+import Input from "@/components/ui/Input";
+import Label from "@/components/ui/Label";
+import Button from "@/components/ui/Button";
+import { useToast } from "@/components/ToastProvider";
+
+function formatForInput(value?: string | null) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+type ActionResult = {
+  success: boolean;
+  id?: string;
+  error?: string;
+  errors?: Record<string, string[]>;
+};
+
+type Action = (formData: FormData) => Promise<ActionResult>;
+
+type EventFormProps = {
+  action: Action;
+  initial?: {
+    id?: string;
+    title?: string;
+    date?: string | null;
+    description?: string | null;
+    audience?: string[] | null;
+  };
+  redirectTo: string;
+  submitLabel?: string;
+};
+
+export default function EventForm({ action, initial, redirectTo, submitLabel = "Save" }: EventFormProps) {
+  const router = useRouter();
+  const toast = useToast();
+  const [state, formAction, pending] = useActionState<ActionResult | null>(async (_prev, formData: FormData) => {
+    const response = await action(formData);
+    if (response.success) {
+      toast.addToast({ title: "Saved", description: "Event saved successfully", variant: "success" });
+      router.push(redirectTo.replace(":id", response.id || ""));
+      router.refresh();
+    }
+    return response;
+  }, null);
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {state?.error ? <div className="text-sm text-red-500">{state.error}</div> : null}
+      <Label>
+        <span>Title</span>
+        <Input name="title" defaultValue={initial?.title} placeholder="Ceremony, fixture, or announcement" />
+        {state?.errors?.title?.[0] ? <span className="text-red-500">{state.errors.title[0]}</span> : null}
+      </Label>
+      <Label>
+        <span>Date &amp; time</span>
+        <Input type="datetime-local" name="date" defaultValue={formatForInput(initial?.date)} />
+        {state?.errors?.date?.[0] ? <span className="text-red-500">{state.errors.date[0]}</span> : null}
+      </Label>
+      <Label>
+        <span>Description</span>
+        <textarea
+          name="description"
+          defaultValue={initial?.description ?? ""}
+          placeholder="Context, objectives, dress code, or logistics"
+          rows={3}
+          className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/60 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand)]"
+        />
+        {state?.errors?.description?.[0] ? <span className="text-red-500">{state.errors.description[0]}</span> : null}
+      </Label>
+      <Label>
+        <span>Audience</span>
+        <Input
+          name="audience"
+          defaultValue={Array.isArray(initial?.audience) ? initial.audience.join(", ") : ""}
+          placeholder="Students, Guardians, Teachers"
+        />
+        <span className="text-xs text-white/50">Separate multiple audiences with commas.</span>
+        {state?.errors?.audience?.[0] ? <span className="text-red-500">{state.errors.audience[0]}</span> : null}
+      </Label>
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : submitLabel}
+        </Button>
+        <Button type="button" variant="secondary" onClick={() => router.back()}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/EventListClient.tsx
+++ b/src/components/EventListClient.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import Input from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
+import Badge from "@/components/ui/Badge";
+
+export type EventRecord = {
+  id: string;
+  title: string;
+  date: string;
+  description?: string | null;
+  audience?: string[] | null;
+};
+
+type TimelineEvent = EventRecord & {
+  dateObject: Date;
+  dateLabel: string;
+  timeLabel: string;
+  relative: string;
+  status: "upcoming" | "past";
+};
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+const relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+function formatRelative(date: Date) {
+  const now = Date.now();
+  const diff = date.getTime() - now;
+  const minutes = Math.round(diff / (1000 * 60));
+  if (Math.abs(minutes) < 60) {
+    return relativeFormatter.format(minutes, "minute");
+  }
+  const hours = Math.round(minutes / 60);
+  if (Math.abs(hours) < 24) {
+    return relativeFormatter.format(hours, "hour");
+  }
+  const days = Math.round(hours / 24);
+  if (Math.abs(days) < 30) {
+    return relativeFormatter.format(days, "day");
+  }
+  const months = Math.round(days / 30);
+  return relativeFormatter.format(months, "month");
+}
+
+function normaliseEvent(record: EventRecord): TimelineEvent | null {
+  const dateObject = new Date(record.date);
+  if (Number.isNaN(dateObject.getTime())) {
+    return null;
+  }
+  const status = dateObject.getTime() >= Date.now() ? "upcoming" : "past";
+  return {
+    ...record,
+    dateObject,
+    status,
+    dateLabel: dateFormatter.format(dateObject),
+    timeLabel: timeFormatter.format(dateObject),
+    relative: formatRelative(dateObject),
+  };
+}
+
+function getAudienceOptions(events: TimelineEvent[]) {
+  const entries = new Set<string>();
+  for (const event of events) {
+    for (const value of event.audience ?? []) {
+      entries.add(value);
+    }
+  }
+  return Array.from(entries.values()).sort();
+}
+
+export default function EventListClient({ events }: { events: EventRecord[] }) {
+  const [query, setQuery] = useState("");
+  const [view, setView] = useState<"upcoming" | "past" | "all">("upcoming");
+  const [audience, setAudience] = useState("all");
+
+  const timelineEvents = useMemo(() => {
+    return events
+      .map(normaliseEvent)
+      .filter((value): value is TimelineEvent => Boolean(value))
+      .sort((a, b) => a.dateObject.getTime() - b.dateObject.getTime());
+  }, [events]);
+
+  const audienceOptions = useMemo(() => getAudienceOptions(timelineEvents), [timelineEvents]);
+
+  const filtered = useMemo(() => {
+    const queryLower = query.trim().toLowerCase();
+    return timelineEvents.filter((event) => {
+      if (view !== "all" && event.status !== view) {
+        return false;
+      }
+      if (audience !== "all") {
+        if (!event.audience?.some((value) => value === audience)) {
+          return false;
+        }
+      }
+      if (!queryLower) {
+        return true;
+      }
+      const haystack = [event.title, event.description ?? "", (event.audience ?? []).join(" ")]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(queryLower);
+    });
+  }, [timelineEvents, query, view, audience]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-3 text-sm">
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search title, audience, or description"
+          className="min-w-[220px]"
+        />
+        <Select value={view} onChange={(event) => setView(event.target.value as typeof view)}>
+          <option value="upcoming">Upcoming</option>
+          <option value="past">Past</option>
+          <option value="all">All</option>
+        </Select>
+        <Select value={audience} onChange={(event) => setAudience(event.target.value)}>
+          <option value="all">All audiences</option>
+          {audienceOptions.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </Select>
+      </div>
+
+      <div className="space-y-3">
+        {filtered.length === 0 ? (
+          <div className="card p-6 text-sm text-white/70">
+            <p className="font-medium text-white">No events yet.</p>
+            <p className="mt-1">
+              Adjust your filters or schedule a new event to populate the communications timeline.
+            </p>
+          </div>
+        ) : (
+          <ol className="space-y-4">
+            {filtered.map((event) => (
+              <li key={event.id} className="relative">
+                <Link
+                  href={`/events/${event.id}`}
+                  className="group block rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-[var(--brand)]/60 hover:bg-white/10"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="text-lg font-semibold text-white group-hover:text-[var(--brand-500)]">
+                          {event.title}
+                        </h2>
+                        <Badge color={event.status === "upcoming" ? "green" : "blue"}>{event.relative}</Badge>
+                      </div>
+                      <p className="mt-1 text-sm text-white/70 leading-relaxed">
+                        {event.description || "No description provided."}
+                      </p>
+                      {event.audience?.length ? (
+                        <div className="mt-2 flex flex-wrap gap-2 text-xs text-white/60">
+                          {event.audience.map((value) => (
+                            <span
+                              key={value}
+                              className="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-2 py-1"
+                            >
+                              {value}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="shrink-0 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-right text-sm text-white/80">
+                      <div className="font-semibold text-white">{event.dateLabel}</div>
+                      <div>{event.timeLabel}</div>
+                    </div>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/StaffListClient.tsx
+++ b/src/components/StaffListClient.tsx
@@ -1,79 +1,262 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import Input from "@/components/ui/Input";
 import Select from "@/components/ui/Select";
-import Link from "next/link";
+import Badge from "@/components/ui/Badge";
 
-export default function StaffListClient({ staff }: { staff: any[] }) {
-  const [q, setQ] = useState("");
-  const [status, setStatus] = useState("");
-  const [role, setRole] = useState("");
-  const [dense, setDense] = useState(false);
+type StaffRecord = {
+  id: string;
+  name: string;
+  status: string;
+  role: string;
+  dob?: string | null;
+  phone?: string | null;
+  stateOfOrigin?: string | null;
+  disabilities?: unknown;
+  rank?: string | null;
+  salary?: number | null;
+  subjects?: unknown;
+  department?: string | null;
+  sanction?: string | null;
+  clubs?: unknown;
+  qualification?: string | null;
+};
+
+type ViewMode = "cards" | "table";
+
+function normaliseArray(value: unknown) {
+  if (!value) return [] as string[];
+  if (Array.isArray(value)) {
+    return value.map((entry) => (typeof entry === "string" ? entry.trim() : "")).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return [] as string[];
+}
+
+function formatStatusTone(status: string) {
+  switch (status) {
+    case "active":
+      return "green" as const;
+    case "retired":
+      return "blue" as const;
+    case "suspended":
+      return "red" as const;
+    default:
+      return "gray" as const;
+  }
+}
+
+export default function StaffListClient({ staff }: { staff: StaffRecord[] }) {
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState("all");
+  const [role, setRole] = useState("all");
+  const [view, setView] = useState<ViewMode>("cards");
+
   const filtered = useMemo(() => {
-    return staff.filter((m) => {
-      const matchesQ = q ? m.name.toLowerCase().includes(q.toLowerCase()) : true;
-      const matchesStatus = status ? m.status === status : true;
-      const matchesRole = role ? m.role === role : true;
-      return matchesQ && matchesStatus && matchesRole;
+    const q = query.trim().toLowerCase();
+    return staff.filter((member) => {
+      const matchesQuery = q
+        ? [
+            member.name,
+            member.department ?? "",
+            member.rank ?? "",
+            normaliseArray(member.subjects).join(" "),
+            normaliseArray(member.clubs).join(" "),
+          ]
+            .join(" ")
+            .toLowerCase()
+            .includes(q)
+        : true;
+      const matchesStatus = status === "all" ? true : member.status === status;
+      const matchesRole = role === "all" ? true : member.role === role;
+      return matchesQuery && matchesStatus && matchesRole;
     });
-  }, [staff, q, status, role]);
+  }, [staff, query, status, role]);
 
   return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap gap-2 items-center">
-        <Input placeholder="Search name…" value={q} onChange={(e) => setQ(e.target.value)} />
-        <Select value={status} onChange={(e) => setStatus(e.target.value)}>
-          <option value="">All statuses</option>
-          <option>active</option>
-          <option>inactive</option>
-          <option>suspended</option>
-          <option>retired</option>
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-3">
+        <Input
+          placeholder="Search by name, department, subject, or club…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          className="min-w-[240px] flex-1 sm:flex-none"
+        />
+        <Select value={status} onChange={(event) => setStatus(event.target.value)} className="bg-white/5 text-white">
+          <option value="all">All statuses</option>
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+          <option value="suspended">Suspended</option>
+          <option value="retired">Retired</option>
         </Select>
-        <Select value={role} onChange={(e) => setRole(e.target.value)}>
-          <option value="">All roles</option>
-          <option value="academic">academic</option>
-          <option value="admin">admin</option>
+        <Select value={role} onChange={(event) => setRole(event.target.value)} className="bg-white/5 text-white">
+          <option value="all">All roles</option>
+          <option value="academic">Academic</option>
+          <option value="admin">Admin</option>
         </Select>
-        <label className="text-sm flex items-center gap-2">
-          <input type="checkbox" checked={dense} onChange={(e) => setDense(e.target.checked)} />
-          Dense
-        </label>
+        <div className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 p-1 text-xs uppercase tracking-[0.24em]">
+          <button
+            type="button"
+            onClick={() => setView("cards")}
+            className={`rounded-full px-3 py-1 transition ${
+              view === "cards" ? "bg-white text-black shadow" : "text-white/60 hover:text-white"
+            }`}
+          >
+            Cards
+          </button>
+          <button
+            type="button"
+            onClick={() => setView("table")}
+            className={`rounded-full px-3 py-1 transition ${
+              view === "table" ? "bg-white text-black shadow" : "text-white/60 hover:text-white"
+            }`}
+          >
+            Ledger
+          </button>
+        </div>
       </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm border">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="text-left p-2 border">Name</th>
-              <th className="text-left p-2 border">Status</th>
-              <th className="text-left p-2 border">Role</th>
-              <th className="text-left p-2 border">Department</th>
-              <th className="text-left p-2 border">Rank</th>
-              <th className="text-left p-2 border">Salary</th>
-              <th className="text-left p-2 border">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.length === 0 ? (
+
+      {filtered.length === 0 ? (
+        <div className="card border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+          <p className="text-base font-semibold text-white">No staff members match these filters.</p>
+          <p className="mt-1">Update the search or onboard personnel to populate the directory.</p>
+        </div>
+      ) : view === "cards" ? (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {filtered.map((member) => {
+            const subjects = normaliseArray(member.subjects);
+            const clubs = normaliseArray(member.clubs);
+            const disabilities = normaliseArray(member.disabilities);
+            return (
+              <article
+                key={member.id}
+                className="group flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-gradient-to-br from-white/5 via-white/0 to-white/5 p-6 transition hover:border-[var(--brand)]/60 hover:bg-white/10"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <Link href={`/staff/${member.id}`} className="text-lg font-semibold text-white transition group-hover:text-[var(--brand-400)]">
+                      {member.name}
+                    </Link>
+                    <div className="mt-1 text-sm text-white/60">{member.department || "Department pending"}</div>
+                  </div>
+                  <Badge color={formatStatusTone(member.status)}>{member.status}</Badge>
+                </div>
+
+                <div className="grid gap-3 text-sm text-white/70">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-white/60">Role</span>
+                    <span className="text-right text-white capitalize">{member.role}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-white/60">Rank</span>
+                    <span className="text-right text-white">{member.rank || "—"}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-white/60">Salary</span>
+                    <span className="text-right text-white">{member.salary != null ? member.salary.toLocaleString() : "—"}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-white/60">Qualification</span>
+                    <span className="text-right text-white">{member.qualification || "—"}</span>
+                  </div>
+                  {member.phone ? (
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-white/60">Phone</span>
+                      <a className="text-right text-[var(--brand-200)] hover:text-[var(--brand)]" href={`tel:${member.phone}`}>
+                        {member.phone}
+                      </a>
+                    </div>
+                  ) : null}
+                  {member.sanction ? (
+                    <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-rose-100">
+                      {member.sanction}
+                    </div>
+                  ) : null}
+                </div>
+
+                {[subjects, clubs, disabilities].some((collection) => collection.length) ? (
+                  <div className="flex flex-wrap gap-2 text-xs text-white/65">
+                    {subjects.map((subject) => (
+                      <span key={`subject-${subject}`} className="rounded-full border border-white/15 bg-white/10 px-2 py-1">
+                        {subject}
+                      </span>
+                    ))}
+                    {clubs.map((club) => (
+                      <span key={`club-${club}`} className="rounded-full border border-sky-400/30 bg-sky-500/10 px-2 py-1 text-sky-100">
+                        {club}
+                      </span>
+                    ))}
+                    {disabilities.map((item) => (
+                      <span key={`disability-${item}`} className="rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-1 text-amber-100">
+                        {item}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+
+                <div className="flex items-center justify-between text-xs text-white/50">
+                  <span>{member.dob ? new Date(member.dob).toLocaleDateString() : "Date of birth pending"}</span>
+                  <Link href={`/staff/${member.id}/edit`} className="font-medium text-[var(--brand-200)] hover:text-[var(--brand)]">
+                    Edit profile ↗
+                  </Link>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-3xl border border-white/10 bg-black/40">
+          <table className="min-w-full divide-y divide-white/10 text-sm">
+            <thead className="bg-white/5 text-xs uppercase tracking-[0.28em] text-white/50">
               <tr>
-                <td className="p-2 border text-center" colSpan={7}>No staff</td>
+                <th className="px-4 py-3 text-left font-medium">Staff</th>
+                <th className="px-4 py-3 text-left font-medium">Role</th>
+                <th className="px-4 py-3 text-left font-medium">Department</th>
+                <th className="px-4 py-3 text-left font-medium">Rank</th>
+                <th className="px-4 py-3 text-left font-medium">Salary</th>
+                <th className="px-4 py-3 text-left font-medium">Contact</th>
+                <th className="px-4 py-3 text-right font-medium">Actions</th>
               </tr>
-            ) : (
-              filtered.map((m) => (
-                <tr key={m.id} className={dense ? "text-[13px]" : undefined}>
-                  <td className="p-2 border"><Link href={`/staff/${m.id}`}>{m.name}</Link></td>
-                  <td className="p-2 border">{m.status}</td>
-                  <td className="p-2 border">{m.role}</td>
-                  <td className="p-2 border">{m.department || "—"}</td>
-                  <td className="p-2 border">{m.rank || "—"}</td>
-                  <td className="p-2 border">{m.salary ?? "—"}</td>
-                  <td className="p-2 border text-blue-600"><Link href={`/staff/${m.id}/edit`}>Edit</Link></td>
+            </thead>
+            <tbody className="divide-y divide-white/10 text-white/80">
+              {filtered.map((member) => (
+                <tr key={member.id} className="hover:bg-white/5">
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-white">
+                      <Link href={`/staff/${member.id}`}>{member.name}</Link>
+                    </div>
+                    <div className="mt-1">
+                      <Badge color={formatStatusTone(member.status)}>{member.status}</Badge>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 capitalize">{member.role}</td>
+                  <td className="px-4 py-3">{member.department || "—"}</td>
+                  <td className="px-4 py-3">{member.rank || "—"}</td>
+                  <td className="px-4 py-3">{member.salary != null ? member.salary.toLocaleString() : "—"}</td>
+                  <td className="px-4 py-3">
+                    {member.phone ? <div>{member.phone}</div> : <span>—</span>}
+                    {member.stateOfOrigin ? (
+                      <div className="text-xs text-white/60">{member.stateOfOrigin}</div>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <Link href={`/staff/${member.id}/edit`} className="text-[var(--brand-200)] hover:text-[var(--brand)]">
+                      Edit
+                    </Link>
+                  </td>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/StudentListClient.tsx
+++ b/src/components/StudentListClient.tsx
@@ -1,74 +1,275 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import Input from "@/components/ui/Input";
 import Select from "@/components/ui/Select";
-import Link from "next/link";
+import Badge from "@/components/ui/Badge";
 
-export default function StudentListClient({ students }: { students: any[] }) {
-  const [q, setQ] = useState("");
-  const [status, setStatus] = useState("");
-  const [dense, setDense] = useState(false);
+type StudentRecord = {
+  id: string;
+  name: string;
+  status: string;
+  dob?: string | null;
+  photoUrl?: string | null;
+  guardian?: unknown;
+  stateOfOrigin?: string | null;
+  scholarship?: string | null;
+  financialStatus?: string | null;
+  medicalIssues?: unknown;
+  disabilities?: unknown;
+  sanction?: string | null;
+  clubs?: unknown;
+  cgpa?: number | null;
+  classOfDegree?: string | null;
+};
+
+type ViewMode = "gallery" | "table";
+
+function normaliseArray(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function extractGuardian(value: unknown) {
+  if (!value || typeof value !== "object") return { name: "—", phone: undefined as string | undefined };
+  const record = value as { name?: unknown; phone?: unknown };
+  return {
+    name: typeof record.name === "string" && record.name.trim() ? record.name : "—",
+    phone: typeof record.phone === "string" && record.phone.trim() ? record.phone : undefined,
+  };
+}
+
+function formatStatusTone(status: string) {
+  switch (status) {
+    case "active":
+      return "green" as const;
+    case "graduated":
+      return "blue" as const;
+    case "suspended":
+      return "red" as const;
+    default:
+      return "gray" as const;
+  }
+}
+
+export default function StudentListClient({ students }: { students: StudentRecord[] }) {
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState("all");
+  const [view, setView] = useState<ViewMode>("gallery");
+
   const filtered = useMemo(() => {
-    return students.filter((s) => {
-      const matchesQ = q ? s.name.toLowerCase().includes(q.toLowerCase()) : true;
-      const matchesStatus = status ? s.status === status : true;
-      return matchesQ && matchesStatus;
+    const normalisedQuery = query.trim().toLowerCase();
+    return students.filter((student) => {
+      const matchesQuery = normalisedQuery
+        ? [
+            student.name,
+            student.stateOfOrigin ?? "",
+            student.scholarship ?? "",
+            student.financialStatus ?? "",
+            normaliseArray(student.clubs).join(" "),
+            normaliseArray(student.disabilities).join(" "),
+          ]
+            .join(" ")
+            .toLowerCase()
+            .includes(normalisedQuery)
+        : true;
+      const matchesStatus = status === "all" ? true : student.status === status;
+      return matchesQuery && matchesStatus;
     });
-  }, [students, q, status]);
+  }, [students, query, status]);
 
   return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap gap-2 items-center">
-        <Input placeholder="Search name…" value={q} onChange={(e) => setQ(e.target.value)} />
-        <Select value={status} onChange={(e) => setStatus(e.target.value)}>
-          <option value="">All statuses</option>
-          <option>active</option>
-          <option>inactive</option>
-          <option>suspended</option>
-          <option>graduated</option>
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-3">
+        <Input
+          placeholder="Search by name, club, scholarship, or state…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          className="min-w-[240px] flex-1 sm:flex-none"
+        />
+        <Select value={status} onChange={(event) => setStatus(event.target.value)} className="bg-white/5 text-white">
+          <option value="all">All statuses</option>
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+          <option value="suspended">Suspended</option>
+          <option value="graduated">Graduated</option>
         </Select>
-        <label className="text-sm flex items-center gap-2">
-          <input type="checkbox" checked={dense} onChange={(e) => setDense(e.target.checked)} />
-          Dense
-        </label>
+        <div className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 p-1 text-xs uppercase tracking-[0.24em]">
+          <button
+            type="button"
+            onClick={() => setView("gallery")}
+            className={`rounded-full px-3 py-1 transition ${
+              view === "gallery" ? "bg-white text-black shadow" : "text-white/60 hover:text-white"
+            }`}
+          >
+            Gallery
+          </button>
+          <button
+            type="button"
+            onClick={() => setView("table")}
+            className={`rounded-full px-3 py-1 transition ${
+              view === "table" ? "bg-white text-black shadow" : "text-white/60 hover:text-white"
+            }`}
+          >
+            Ledger
+          </button>
+        </div>
       </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm border">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="text-left p-2 border">Name</th>
-              <th className="text-left p-2 border">Status</th>
-              <th className="text-left p-2 border">DOB</th>
-              <th className="text-left p-2 border">Guardian</th>
-              <th className="text-left p-2 border">State of Origin</th>
-              <th className="text-left p-2 border">Scholarship</th>
-              <th className="text-left p-2 border">CGPA</th>
-              <th className="text-left p-2 border">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.length === 0 ? (
+
+      {filtered.length === 0 ? (
+        <div className="card border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+          <p className="text-base font-semibold text-white">No student records match these filters.</p>
+          <p className="mt-1">Adjust your search criteria or onboard a new learner to populate the directory.</p>
+        </div>
+      ) : view === "gallery" ? (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {filtered.map((student) => {
+            const guardian = extractGuardian(student.guardian);
+            const clubs = normaliseArray(student.clubs);
+            const medical = normaliseArray(student.medicalIssues);
+            const disabilities = normaliseArray(student.disabilities);
+            return (
+              <article
+                key={student.id}
+                className="group relative flex flex-col gap-4 overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-white/5 via-white/0 to-white/5 p-6 transition hover:border-[var(--brand)]/60 hover:bg-white/10"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <Link href={`/students/${student.id}`} className="text-lg font-semibold text-white transition group-hover:text-[var(--brand-400)]">
+                      {student.name}
+                    </Link>
+                    <div className="mt-1 text-sm text-white/60">{student.stateOfOrigin || "State not set"}</div>
+                  </div>
+                  <Badge color={formatStatusTone(student.status)}>{student.status}</Badge>
+                </div>
+
+                <div className="grid gap-3 text-sm text-white/70">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-white/60">Guardian</span>
+                    <span className="text-right text-white">{guardian.name}</span>
+                  </div>
+                  {guardian.phone ? (
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-white/60">Guardian line</span>
+                      <a className="text-right text-[var(--brand-200)] hover:text-[var(--brand)]" href={`tel:${guardian.phone}`}>
+                        {guardian.phone}
+                      </a>
+                    </div>
+                  ) : null}
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-white/60">Scholarship</span>
+                    <span className="text-right text-white">{student.scholarship || "—"}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-white/60">Financial status</span>
+                    <span className="text-right text-white">{student.financialStatus || "—"}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-white/60">CGPA</span>
+                    <span className="text-right text-white">{student.cgpa != null ? student.cgpa.toFixed(2) : "—"}</span>
+                  </div>
+                  {student.classOfDegree ? (
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-white/60">Class of degree</span>
+                      <span className="text-right text-white">{student.classOfDegree}</span>
+                    </div>
+                  ) : null}
+                  {student.sanction ? (
+                    <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-rose-100">
+                      {student.sanction}
+                    </div>
+                  ) : null}
+                </div>
+
+                {[clubs, medical, disabilities].some((collection) => collection.length) ? (
+                  <div className="flex flex-wrap gap-2 text-xs text-white/65">
+                    {clubs.map((club) => (
+                      <span key={`club-${club}`} className="rounded-full border border-white/15 bg-white/10 px-2 py-1">
+                        {club}
+                      </span>
+                    ))}
+                    {medical.map((item) => (
+                      <span key={`medical-${item}`} className="rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-1 text-amber-100">
+                        {item}
+                      </span>
+                    ))}
+                    {disabilities.map((item) => (
+                      <span key={`disability-${item}`} className="rounded-full border border-sky-400/30 bg-sky-500/10 px-2 py-1 text-sky-100">
+                        {item}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+
+                <div className="flex items-center justify-between text-xs text-white/50">
+                  <span>{student.dob ? new Date(student.dob).toLocaleDateString() : "Date of birth pending"}</span>
+                  <Link href={`/students/${student.id}/edit`} className="font-medium text-[var(--brand-200)] hover:text-[var(--brand)]">
+                    Edit profile ↗
+                  </Link>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-3xl border border-white/10 bg-black/40">
+          <table className="min-w-full divide-y divide-white/10 text-sm">
+            <thead className="bg-white/5 text-xs uppercase tracking-[0.28em] text-white/50">
               <tr>
-                <td className="p-2 border text-center" colSpan={8}>No students</td>
+                <th className="px-4 py-3 text-left font-medium">Student</th>
+                <th className="px-4 py-3 text-left font-medium">Status</th>
+                <th className="px-4 py-3 text-left font-medium">Scholarship</th>
+                <th className="px-4 py-3 text-left font-medium">Financial</th>
+                <th className="px-4 py-3 text-left font-medium">CGPA</th>
+                <th className="px-4 py-3 text-left font-medium">Guardian</th>
+                <th className="px-4 py-3 text-right font-medium">Actions</th>
               </tr>
-            ) : (
-              filtered.map((s) => (
-                <tr key={s.id} className={dense ? "text-[13px]" : undefined}>
-                  <td className="p-2 border"><Link href={`/students/${s.id}`}>{s.name}</Link></td>
-                  <td className="p-2 border">{s.status}</td>
-                  <td className="p-2 border">{s.dob || "—"}</td>
-                  <td className="p-2 border">{(s.guardian as any)?.name || "—"}</td>
-                  <td className="p-2 border">{s.stateOfOrigin || "—"}</td>
-                  <td className="p-2 border">{s.scholarship || "—"}</td>
-                  <td className="p-2 border">{s.cgpa ?? "—"}</td>
-                  <td className="p-2 border text-blue-600"><Link href={`/students/${s.id}/edit`}>Edit</Link></td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody className="divide-y divide-white/10 text-white/80">
+              {filtered.map((student) => {
+                const guardian = extractGuardian(student.guardian);
+                return (
+                  <tr key={student.id} className="hover:bg-white/5">
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-white">
+                        <Link href={`/students/${student.id}`}>{student.name}</Link>
+                      </div>
+                      <div className="text-xs text-white/60">{student.stateOfOrigin || "—"}</div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge color={formatStatusTone(student.status)}>{student.status}</Badge>
+                    </td>
+                    <td className="px-4 py-3">{student.scholarship || "—"}</td>
+                    <td className="px-4 py-3">{student.financialStatus || "—"}</td>
+                    <td className="px-4 py-3">{student.cgpa != null ? student.cgpa.toFixed(2) : "—"}</td>
+                    <td className="px-4 py-3">
+                      <div>{guardian.name}</div>
+                      {guardian.phone ? <div className="text-xs text-white/60">{guardian.phone}</div> : null}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <Link href={`/students/${student.id}/edit`} className="text-[var(--brand-200)] hover:text-[var(--brand)]">
+                        Edit
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -5,7 +5,7 @@ import React from "react";
 export default function Select({ className = "", ...props }: React.SelectHTMLAttributes<HTMLSelectElement>) {
   return (
     <select
-      className={`border rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-[var(--brand)] focus:border-[var(--brand)] transition ${className}`}
+      className={`border border-white/10 bg-white/5 text-white rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-[var(--brand)] focus:border-[var(--brand)] transition ${className}`}
       {...props}
     />
   );

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,6 @@
 import {
   AcademicRecord,
+  EventItem,
   FinancialEntry,
   MockData,
   Student,
@@ -34,9 +35,9 @@ const generateId = () => `id_${Math.random().toString(36).slice(2, 10)}`;
 
 const now = () => new Date().toISOString();
 
-type TableItem = Student | Staff | FinancialEntry | AcademicRecord;
+type TableItem = Student | Staff | FinancialEntry | AcademicRecord | EventItem;
 
-type TableName = "students" | "staff" | "financialEntries" | "academicRecords";
+type TableName = "students" | "staff" | "financialEntries" | "academicRecords" | "events";
 
 interface TableConfig<T extends TableItem> {
   name: TableName;
@@ -183,6 +184,7 @@ interface PrismaMock {
   staff: InMemoryTable<Staff>;
   financialEntry: InMemoryTable<FinancialEntry>;
   academicRecord: InMemoryTable<AcademicRecord>;
+  eventItem: InMemoryTable<EventItem>;
 }
 
 declare global {
@@ -204,6 +206,7 @@ const createPrisma = (data: MockData): PrismaMock => ({
       return {};
     },
   }),
+  eventItem: new InMemoryTable<EventItem>(data, { name: "events" }),
 });
 
 if (!globalThis.__mockData) {

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -94,6 +94,16 @@ export interface AcademicRecord {
   updatedAt: string;
 }
 
+export interface EventItem {
+  id: string;
+  title: string;
+  date: string;
+  description?: string | null;
+  audience?: string[] | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 const now = () => new Date().toISOString();
 
 export interface MockData {
@@ -101,6 +111,7 @@ export interface MockData {
   staff: Staff[];
   financialEntries: FinancialEntry[];
   academicRecords: AcademicRecord[];
+  events: EventItem[];
 }
 
 const today = new Date();
@@ -226,6 +237,35 @@ export const initialData: MockData = {
       attendance: 95,
       grade: "A",
       cgpa: 4.8,
+      createdAt: now(),
+      updatedAt: now(),
+    },
+  ],
+  events: [
+    {
+      id: "evt_1",
+      title: "PTA General Assembly",
+      date: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 7).toISOString(),
+      description: "Quarterly briefing with guardians on academic progress and upcoming projects.",
+      audience: ["Guardians", "Teachers"],
+      createdAt: now(),
+      updatedAt: now(),
+    },
+    {
+      id: "evt_2",
+      title: "Science Fair Showcase",
+      date: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 21).toISOString(),
+      description: "Students present STEM innovations for community judging.",
+      audience: ["Students", "Community"],
+      createdAt: now(),
+      updatedAt: now(),
+    },
+    {
+      id: "evt_3",
+      title: "Teachers' Capacity Workshop",
+      date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 12).toISOString(),
+      description: "Professional development on differentiated learning and assessment.",
+      audience: ["Teachers"],
       createdAt: now(),
       updatedAt: now(),
     },

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -95,3 +95,19 @@ export const AcademicInputSchema = z.object({
 });
 
 export type AcademicInput = z.infer<typeof AcademicInputSchema>;
+
+export const EventInputSchema = z.object({
+  title: z.string().trim().min(1, "Title is required"),
+  date: z
+    .string()
+    .trim()
+    .min(1, "Date is required")
+    .refine((value) => {
+      const timestamp = Date.parse(value);
+      return Number.isFinite(timestamp);
+    }, "Enter a valid date"),
+  description: z.string().optional().or(z.literal("")),
+  audience: z.string().optional().or(z.literal("")),
+});
+
+export type EventInput = z.infer<typeof EventInputSchema>;


### PR DESCRIPTION
## Summary
- refresh the students and staff workspaces with insight cards, elevated directory toggles, and richer profile chips
- rebuild the performance centre as an analytics hub highlighting term trends and top performers
- turn the financial dashboards into a polished command centre across overview, income, and expense flows

## Testing
- pnpm lint *(fails: existing `@typescript-eslint/no-explicit-any` violations in legacy forms and actions)*

------
https://chatgpt.com/codex/tasks/task_e_68da0be0f90c832f99966185c283e4ac