### PR TITLE
Refresh header styling and improve dropdown readability

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,26 @@
 @import "tailwindcss";
 
 :root {
-  /* Matte black + crimson theme */
-  --background: #050505;
-  --foreground: #f4f4f5;
-  --muted: #101010;
-  --border: #1a1a1a;
+  /* Midnight indigo + crimson glow theme */
+  --background: #0b1220;
+  --foreground: #f8fafc;
+  --muted: #131c2e;
+  --border: rgba(148, 163, 184, 0.18);
 
   /* Accents */
   --scarlet: #ef233c;
   --crimson: #d90429;
   --ember: #ba041f;
-  --ashen: #171717;
+  --ashen: #15203a;
   --brand: var(--crimson);
   --brand-500: var(--scarlet);
   --brand-600: #c1021f;
   --brand-700: #8a0017;
 
-  --ink: #050505;
-  --slate-500: #9b9b9b;
-  --slate-600: #b2b2b2;
-  --slate-700: #d3d3d3;
+  --ink: #0b1220;
+  --slate-500: #8aa3d0;
+  --slate-600: #a7b8dc;
+  --slate-700: #d7e0f5;
 }
 
 @theme inline {
@@ -36,11 +36,12 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans), ui-sans-serif, system-ui, -apple-system;
-  /* Ambient crimson glow */
+  /* Ambient aurora */
   background-image:
-    radial-gradient(62rem 62rem at -10% -10%, rgba(217,4,41,0.22), transparent 70%),
-    radial-gradient(56rem 56rem at 110% -10%, rgba(239,35,60,0.16), transparent 70%),
-    radial-gradient(72rem 72rem at 50% 120%, rgba(138,0,23,0.22), transparent 70%);
+    radial-gradient(70rem 70rem at -10% -20%, rgba(59,130,246,0.22), transparent 65%),
+    radial-gradient(68rem 68rem at 110% 0%, rgba(217,4,41,0.25), transparent 70%),
+    radial-gradient(90rem 90rem at 45% 120%, rgba(56,189,248,0.18), transparent 70%),
+    linear-gradient(180deg, rgba(6,11,25,0.88), rgba(9,14,30,0.96));
   background-attachment: fixed;
 }
 
@@ -50,17 +51,17 @@ body {
 
 /* Simple card utility */
 .card {
-  background: linear-gradient(180deg, rgba(18,18,18,0.92), rgba(12,12,12,0.86));
+  background: linear-gradient(180deg, rgba(19,28,46,0.9), rgba(12,18,32,0.85));
   border: 1px solid var(--border);
-  border-radius: 16px;
-  box-shadow: 0 18px 60px -32px rgba(0,0,0,0.8), 0 2px 12px rgba(0,0,0,0.45);
+  border-radius: 18px;
+  box-shadow: 0 25px 70px -40px rgba(15,23,42,0.9), 0 4px 18px rgba(15,23,42,0.35);
 }
 
 /* Glass surfaces */
 .glass {
-  background: linear-gradient(180deg, rgba(8,8,8,0.72), rgba(8,8,8,0.52));
-  backdrop-filter: saturate(160%) blur(14px);
-  border: 1px solid rgba(255,255,255,0.05);
+  background: linear-gradient(180deg, rgba(19,28,46,0.68), rgba(12,18,32,0.45));
+  backdrop-filter: saturate(180%) blur(14px);
+  border: 1px solid rgba(148,163,184,0.15);
 }
 
 /* Tables */
@@ -128,8 +129,8 @@ a:hover { color: var(--brand-500); }
   width: 140px;
   height: 36px;
   border-radius: 999px;
-  background: radial-gradient(80% 220% at 50% 50%, rgba(217,4,41,0.35), transparent 70%);
-  filter: blur(10px);
+  background: radial-gradient(80% 220% at 50% 50%, rgba(217,4,41,0.32), rgba(59,130,246,0.28) 65%, transparent 80%);
+  filter: blur(12px);
   opacity: 0;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,47 +45,53 @@ export default function RootLayout({
               Skip to content
             </a>
 
-            <header className="sticky top-0 z-40 border-b border-white/10 bg-[#070707cc] backdrop-blur">
-              <div className="mx-auto grid h-16 w-full max-w-7xl grid-cols-[auto,1fr,auto] items-center gap-4 px-4 sm:px-6 lg:px-8">
+            <header className="sticky top-0 z-40 border-b border-white/10 bg-[#0c1220e6] shadow-[0_18px_40px_-32px_rgba(15,23,42,0.7)] backdrop-blur">
+              <div className="relative mx-auto flex h-20 w-full max-w-7xl items-center justify-between gap-6 px-4 sm:px-6 lg:px-8">
+                <div className="absolute inset-0 -z-10 overflow-hidden">
+                  <div className="absolute inset-x-[-10%] inset-y-[-120%] bg-gradient-to-r from-[rgba(37,99,235,0.18)] via-[rgba(217,4,41,0.24)] to-[rgba(129,140,248,0.18)] blur-3xl" aria-hidden />
+                </div>
                 <Link
                   href="/"
                   aria-label="Go to homepage"
-                  className="flex min-w-0 items-center gap-3"
+                  className="group flex min-w-0 items-center gap-3 rounded-full border border-white/10 bg-white/5 px-3 py-2 transition duration-300 hover:border-white/20 hover:bg-white/10"
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src="/logo.svg"
                     alt="Brand-Stone logo"
-                    className="h-9 w-9 rounded border border-white/10 bg-black/40 p-1"
+                    className="h-9 w-9 rounded-full border border-white/10 bg-black/40 p-1 shadow-[0_10px_30px_-18px_rgba(15,23,42,0.8)]"
                   />
                   <div className="flex min-w-0 flex-col">
-                    <span className="font-display text-base font-semibold tracking-tight text-white">
+                    <span className="font-display text-base font-semibold tracking-tight text-white group-hover:text-white">
                       Brand-Stone
                     </span>
-                    <span className="text-xs uppercase tracking-[0.18em] text-white/60">
+                    <span className="text-xs uppercase tracking-[0.2em] text-white/70">
                       School Suite
                     </span>
                   </div>
                 </Link>
 
-                <div className="flex items-center justify-center">
+                <div className="hidden justify-center md:flex">
                   <Nav />
                 </div>
 
-                <div className="flex items-center justify-end gap-4">
-                  <div className="hidden text-right text-[11px] uppercase tracking-[0.3em] text-white/45 sm:block">
-                    <span className="block">Single sign-on</span>
-                    <span className="block text-white/35">Google Workspace</span>
-                  </div>
-                  <div className="hidden items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.28em] text-white/55 lg:flex">
-                    <span
-                      className="h-2 w-2 rounded-full bg-[var(--brand)] shadow-[0_0_10px_rgba(217,4,41,0.8)]"
-                      aria-hidden
-                    />
+                <div className="flex flex-1 items-center justify-end gap-4">
+                  <div className="hidden items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[11px] uppercase tracking-[0.3em] text-white/70 sm:flex">
+                    <span className="h-2 w-2 rounded-full bg-[var(--brand)] shadow-[0_0_12px_rgba(217,4,41,0.8)]" aria-hidden />
                     Schools only
                   </div>
-                  <UserMenu />
+                  <div className="hidden min-w-[9rem] text-right text-[11px] uppercase tracking-[0.32em] text-white/55 lg:block">
+                    <span className="block">Single sign-on</span>
+                    <span className="block text-white/45">Google Workspace</span>
+                  </div>
+                  <div className="flex items-center gap-3 text-white/90">
+                    <span className="hidden text-[11px] uppercase tracking-[0.3em] text-white/60 sm:block">Profile</span>
+                    <UserMenu />
+                  </div>
                 </div>
+              </div>
+              <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 pb-3 sm:px-6 lg:px-8 md:hidden">
+                <Nav />
               </div>
             </header>
 
@@ -98,7 +104,7 @@ export default function RootLayout({
 
             <CommandPalette />
 
-            <footer className="border-t border-white/10 bg-[#080808]">
+            <footer className="border-t border-white/10 bg-[#0b1324]">
               <div className="container flex flex-col gap-2 py-6 text-sm text-white/60 sm:flex-row sm:items-center sm:justify-between">
                 <span>© {new Date().getFullYear()} School Suite</span>
                 <span>Designed for clarity · Powered by Next.js + Prisma</span>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -63,7 +63,7 @@ export default function Nav() {
 
       {/* Mobile nav */}
       <button
-        className="md:hidden inline-flex items-center justify-center rounded-full border border-white/20 px-2.5 py-1.5 text-white"
+        className="md:hidden inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-2.5 py-1.5 text-white shadow-[0_10px_30px_-24px_rgba(15,23,42,0.8)] transition hover:border-white/30 hover:bg-white/15"
         aria-label="Toggle menu"
         onClick={() => setOpen((v) => !v)}
       >
@@ -72,7 +72,7 @@ export default function Nav() {
         </svg>
       </button>
       {open ? (
-        <div className="absolute right-0 mt-2 w-52 rounded-xl border border-white/10 bg-[#111]/95 p-2 shadow-xl backdrop-blur md:hidden">
+        <div className="absolute right-0 mt-2 w-52 rounded-xl border border-white/15 bg-[#0f172ae6] p-2 shadow-[0_30px_60px_-28px_rgba(15,23,42,0.95)] backdrop-blur md:hidden">
           {links.map((l) => (
             <Link
               key={l.href}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -44,7 +44,7 @@ export default function UserMenu() {
 
   if (loading) {
     return (
-      <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-white/70">
+      <div className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1.5 text-xs text-white/80 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.8)]">
         <Spinner />
         <span>Connecting…</span>
       </div>
@@ -56,7 +56,7 @@ export default function UserMenu() {
       <button
         type="button"
         onClick={() => void signInWithGoogle()}
-        className="inline-flex items-center gap-2 rounded-full bg-white text-black px-3.5 py-1.5 text-sm font-medium shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40"
+        className="inline-flex items-center gap-2 rounded-full bg-white px-3.5 py-1.5 text-sm font-semibold text-slate-900 shadow-[0_15px_35px_-24px_rgba(15,23,42,0.65)] transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(59,130,246,0.65)]"
       >
         <GoogleIcon className="h-4 w-4" />
         School login
@@ -75,7 +75,7 @@ export default function UserMenu() {
       <button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
-        className="flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-left text-sm text-white/90 transition hover:border-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-500)]"
+        className="flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1.5 text-left text-sm text-white/90 shadow-[0_12px_38px_-28px_rgba(15,23,42,0.9)] transition hover:border-white/25 hover:bg-white/15 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(59,130,246,0.65)]"
         aria-haspopup="menu"
         aria-expanded={open}
       >
@@ -99,12 +99,12 @@ export default function UserMenu() {
       {open ? (
         <div
           role="menu"
-          className="absolute right-0 mt-2 w-56 rounded-lg border border-white/10 bg-[#111]/95 p-3 text-sm shadow-xl backdrop-blur"
+          className="absolute right-0 mt-2 w-56 rounded-xl border border-white/15 bg-[#0f172ae6] p-3 text-sm shadow-[0_35px_60px_-28px_rgba(15,23,42,0.95)] backdrop-blur"
         >
           <div className="mb-3 space-y-1">
-            <p className="text-xs uppercase tracking-wide text-white/50">Google Workspace account</p>
+            <p className="text-xs uppercase tracking-wide text-white/60">Google Workspace account</p>
             <p className="font-medium text-white">{user.name}</p>
-            <p className="text-xs text-white/60">{user.email}</p>
+            <p className="text-xs text-white/70">{user.email}</p>
           </div>
           <Link
             href="/students"
@@ -120,7 +120,7 @@ export default function UserMenu() {
               void signOut();
               setOpen(false);
             }}
-            className="mt-2 w-full rounded-md border border-white/10 px-3 py-2 text-white/80 transition hover:bg-white/10"
+            className="mt-2 w-full rounded-md border border-white/15 px-3 py-2 text-white/80 transition hover:bg-white/15"
             role="menuitem"
           >
             Sign out

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -5,7 +5,7 @@ import React from "react";
 export default function Select({ className = "", ...props }: React.SelectHTMLAttributes<HTMLSelectElement>) {
   return (
     <select
-      className={`border border-white/10 bg-white/5 text-white rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-[var(--brand)] focus:border-[var(--brand)] transition ${className}`}
+      className={`rounded-md border border-white/15 bg-white/95 px-3 py-2 text-sm text-slate-900 shadow-[0_18px_36px_-28px_rgba(15,23,42,0.65)] outline-none transition placeholder:text-slate-400 focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand)] ${className}`}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- Reworked the sticky header with a brighter gradient, refined branding container, and integrated profile affordances for a cohesive top bar.
- Updated the global theme to a midnight indigo palette with livelier gradients and deeper shadows for cards and glass surfaces.
- Enhanced navigation and user menu treatments and switched selects to a high-contrast light surface for legible dropdown text.

## Testing
- pnpm lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4accd7fc832f9c3e5b4f9375fc2c