### PR TITLE
Apply crimson rebrand to header and navigation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,25 @@
 @import "tailwindcss";
 
 :root {
-  /* Matte black + crimson theme */
-  --background: #050505;
-  --foreground: #f4f4f5;
-  --muted: #101010;
-  --border: #1a1a1a;
+  /* Brand palette — crimson, white, and refined greys */
+  --background: #f4f4f5;
+  --foreground: #1f1f1f;
+  --muted: #e6e6e7;
+  --border: #d7d7da;
 
-  /* Accents */
-  --scarlet: #ef233c;
-  --crimson: #d90429;
-  --ember: #ba041f;
-  --ashen: #171717;
+  --scarlet: #e41f33;
+  --crimson: #c1121f;
+  --ember: #8f0c18;
+  --ashen: #5f5f63;
   --brand: var(--crimson);
   --brand-500: var(--scarlet);
-  --brand-600: #c1021f;
-  --brand-700: #8a0017;
+  --brand-600: #a50f1c;
+  --brand-700: var(--ember);
 
-  --ink: #050505;
-  --slate-500: #9b9b9b;
-  --slate-600: #b2b2b2;
-  --slate-700: #d3d3d3;
+  --ink: #111113;
+  --slate-500: #6c6c72;
+  --slate-600: #7f7f85;
+  --slate-700: #9a9aa0;
 }
 
 @theme inline {
@@ -30,17 +29,14 @@
   --font-display: var(--font-poppins);
 }
 
-/* No dark mode — single vibrant theme */
-
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans), ui-sans-serif, system-ui, -apple-system;
-  /* Ambient crimson glow */
   background-image:
-    radial-gradient(62rem 62rem at -10% -10%, rgba(217,4,41,0.22), transparent 70%),
-    radial-gradient(56rem 56rem at 110% -10%, rgba(239,35,60,0.16), transparent 70%),
-    radial-gradient(72rem 72rem at 50% 120%, rgba(138,0,23,0.22), transparent 70%);
+    radial-gradient(80rem 60rem at -10% -20%, rgba(196,17,33,0.08), transparent 70%),
+    radial-gradient(70rem 65rem at 120% -10%, rgba(228,31,51,0.06), transparent 70%),
+    linear-gradient(180deg, rgba(255,255,255,0.92), rgba(244,244,245,0.98));
   background-attachment: fixed;
 }
 
@@ -50,17 +46,17 @@ body {
 
 /* Simple card utility */
 .card {
-  background: linear-gradient(180deg, rgba(18,18,18,0.92), rgba(12,12,12,0.86));
+  background: linear-gradient(180deg, rgba(255,255,255,0.96), rgba(250,250,251,0.9));
   border: 1px solid var(--border);
-  border-radius: 16px;
-  box-shadow: 0 18px 60px -32px rgba(0,0,0,0.8), 0 2px 12px rgba(0,0,0,0.45);
+  border-radius: 18px;
+  box-shadow: 0 18px 48px -32px rgba(17, 17, 19, 0.2), 0 2px 8px rgba(17, 17, 19, 0.05);
 }
 
 /* Glass surfaces */
 .glass {
-  background: linear-gradient(180deg, rgba(8,8,8,0.72), rgba(8,8,8,0.52));
-  backdrop-filter: saturate(160%) blur(14px);
-  border: 1px solid rgba(255,255,255,0.05);
+  background: linear-gradient(180deg, rgba(255,255,255,0.72), rgba(244,244,245,0.6));
+  backdrop-filter: saturate(150%) blur(12px);
+  border: 1px solid rgba(215,215,218,0.6);
 }
 
 /* Tables */
@@ -75,8 +71,8 @@ a:hover { color: var(--brand-500); }
 .brand-gradient-animate { animation: gradient-shift 6s ease-in-out infinite alternate; }
 .brand-text { background-image: linear-gradient(135deg, var(--crimson), var(--scarlet)); -webkit-background-clip: text; background-clip: text; color: transparent; }
 .subtle-border { box-shadow: inset 0 0 0 1px var(--border); }
-.elev-1 { box-shadow: 0 6px 20px -12px rgba(16,24,40,0.35), 0 1px 2px rgba(16,24,40,0.04); }
-.elev-2 { box-shadow: 0 20px 60px -30px rgba(16,24,40,0.45), 0 2px 8px rgba(16,24,40,0.08); }
+.elev-1 { box-shadow: 0 6px 18px -14px rgba(17, 17, 19, 0.22), 0 1px 2px rgba(17, 17, 19, 0.06); }
+.elev-2 { box-shadow: 0 22px 60px -34px rgba(17, 17, 19, 0.25), 0 3px 10px rgba(17, 17, 19, 0.08); }
 
 /* Background grid */
 .bg-grid {
@@ -128,7 +124,7 @@ a:hover { color: var(--brand-500); }
   width: 140px;
   height: 36px;
   border-radius: 999px;
-  background: radial-gradient(80% 220% at 50% 50%, rgba(217,4,41,0.35), transparent 70%);
+  background: radial-gradient(80% 220% at 50% 50%, rgba(225,31,51,0.18), rgba(193,18,31,0.24) 55%, transparent 80%);
   filter: blur(10px);
   opacity: 0;
 }
@@ -172,8 +168,8 @@ a:hover { color: var(--brand-500); }
 
 /* Gradient border utility */
 .gradient-border {
-  background: linear-gradient(#101010, #101010) padding-box,
-              linear-gradient(120deg, rgba(217,4,41,0.9), rgba(239,35,60,0.7), rgba(217,4,41,0.9)) border-box;
+  background: linear-gradient(#fdfdfd, #fdfdfd) padding-box,
+              linear-gradient(120deg, rgba(193,18,31,0.9), rgba(228,31,51,0.75), rgba(193,18,31,0.9)) border-box;
   border: 1px solid transparent;
   border-radius: 16px;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,48 +45,42 @@ export default function RootLayout({
               Skip to content
             </a>
 
-            <header className="sticky top-0 z-40 border-b border-white/10 bg-[#070707cc] backdrop-blur">
-              <div className="mx-auto grid h-16 w-full max-w-7xl grid-cols-[auto,1fr,auto] items-center gap-4 px-4 sm:px-6 lg:px-8">
+            <header className="sticky top-0 z-40 border-b border-neutral-200/80 bg-white/95 shadow-sm backdrop-blur">
+              <div className="relative mx-auto flex h-20 w-full max-w-7xl items-center justify-between gap-6 px-4 sm:px-6 lg:px-8">
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 top-1/2 -z-10 bg-gradient-to-b from-transparent via-white to-white" aria-hidden />
                 <Link
                   href="/"
                   aria-label="Go to homepage"
-                  className="flex min-w-0 items-center gap-3"
+                  className="group flex min-w-0 items-center gap-3 rounded-full border border-neutral-200 bg-white px-3 py-2 shadow-sm transition duration-300 hover:border-neutral-300 hover:shadow-md"
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src="/logo.svg"
                     alt="Brand-Stone logo"
-                    className="h-9 w-9 rounded border border-white/10 bg-black/40 p-1"
+                    className="h-9 w-9 rounded-full border border-neutral-200 bg-white p-1 shadow-inner"
                   />
                   <div className="flex min-w-0 flex-col">
-                    <span className="font-display text-base font-semibold tracking-tight text-white">
+                    <span className="font-display text-base font-semibold tracking-tight text-[var(--brand)]">
                       Brand-Stone
                     </span>
-                    <span className="text-xs uppercase tracking-[0.18em] text-white/60">
+                    <span className="text-xs uppercase tracking-[0.22em] text-neutral-500">
                       School Suite
                     </span>
                   </div>
                 </Link>
 
-                <div className="flex items-center justify-center">
+                <div className="hidden justify-center md:flex">
                   <Nav />
                 </div>
 
-                <div className="flex items-center justify-end gap-4">
-                  <div className="hidden text-right text-[11px] uppercase tracking-[0.3em] text-white/45 sm:block">
-                    <span className="block">Single sign-on</span>
-                    <span className="block text-white/35">Google Workspace</span>
-                  </div>
-                  <div className="hidden items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.28em] text-white/55 lg:flex">
-                    <span
-                      className="h-2 w-2 rounded-full bg-[var(--brand)] shadow-[0_0_10px_rgba(217,4,41,0.8)]"
-                      aria-hidden
-                    />
-                    Schools only
-                  </div>
+                <div className="flex flex-1 items-center justify-end gap-4">
                   <UserMenu />
                 </div>
               </div>
+              <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 pb-3 sm:px-6 lg:px-8 md:hidden">
+                <Nav />
+              </div>
+              <div className="h-1 bg-gradient-to-r from-[var(--brand-600)] via-[var(--brand)] to-[var(--brand-500)]" aria-hidden />
             </header>
 
             <main
@@ -98,8 +92,8 @@ export default function RootLayout({
 
             <CommandPalette />
 
-            <footer className="border-t border-white/10 bg-[#080808]">
-              <div className="container flex flex-col gap-2 py-6 text-sm text-white/60 sm:flex-row sm:items-center sm:justify-between">
+            <footer className="border-t border-neutral-200 bg-white/95">
+              <div className="container flex flex-col gap-2 py-6 text-sm text-neutral-600 sm:flex-row sm:items-center sm:justify-between">
                 <span>© {new Date().getFullYear()} School Suite</span>
                 <span>Designed for clarity · Powered by Next.js + Prisma</span>
               </div>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -27,7 +27,7 @@ export default function Nav() {
   return (
     <div className="relative" ref={wrapRef} onMouseLeave={() => setSpot((s) => ({ ...s, visible: false }))}>
       {/* Desktop nav */}
-      <nav className="hidden md:flex gap-5 text-sm items-center text-white/80 relative">
+      <nav className="relative hidden items-center gap-6 text-sm font-medium text-neutral-600 md:flex">
         <motion.span
           className="nav-spot"
           animate={{ left: spot.x - spot.w / 2, top: spot.y - 18, width: spot.w, opacity: spot.visible ? 1 : 0 }}
@@ -49,12 +49,12 @@ export default function Nav() {
             >
               <Link
                 href={l.href}
-                className={`transition-colors ${active ? "text-white" : "hover:text-white"}`}
+                className={`transition-colors ${active ? "text-[var(--brand)]" : "hover:text-neutral-900"}`}
               >
                 {l.label}
               </Link>
               {active ? (
-                <motion.span layoutId="nav-underline" className="absolute left-0 right-0 -bottom-0.5 h-[2px] rounded-full underline-shimmer" />
+                <motion.span layoutId="nav-underline" className="absolute left-0 right-0 -bottom-0.5 h-[2px] rounded-full bg-[var(--brand)]" />
               ) : null}
             </div>
           );
@@ -63,7 +63,7 @@ export default function Nav() {
 
       {/* Mobile nav */}
       <button
-        className="md:hidden inline-flex items-center justify-center rounded-full border border-white/20 px-2.5 py-1.5 text-white"
+        className="inline-flex items-center justify-center rounded-full border border-neutral-300 bg-white px-2.5 py-1.5 text-neutral-700 shadow-sm transition hover:border-neutral-400 hover:text-neutral-900 md:hidden"
         aria-label="Toggle menu"
         onClick={() => setOpen((v) => !v)}
       >
@@ -72,7 +72,7 @@ export default function Nav() {
         </svg>
       </button>
       {open ? (
-        <div className="absolute right-0 mt-2 w-52 rounded-xl border border-white/10 bg-[#111]/95 p-2 shadow-xl backdrop-blur md:hidden">
+        <div className="absolute right-0 mt-2 w-56 rounded-xl border border-neutral-200 bg-white p-2 text-neutral-700 shadow-xl ring-1 ring-black/5 md:hidden">
           {links.map((l) => (
             <Link
               key={l.href}
@@ -80,8 +80,8 @@ export default function Nav() {
               onClick={() => setOpen(false)}
               className={`block px-3 py-2 rounded-md text-sm font-medium ${
                 isActive(l.href)
-                  ? "bg-[var(--brand)] text-white"
-                  : "text-white/90 hover:bg-white/10 hover:text-white"
+                  ? "bg-[var(--brand)] text-white shadow-sm"
+                  : "hover:bg-neutral-100 hover:text-neutral-900"
               }`}
             >
               {l.label}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -22,7 +22,7 @@ function GoogleIcon(props: React.SVGProps<SVGSVGElement>) {
 }
 
 function Spinner() {
-  return <span className="h-4 w-4 animate-spin rounded-full border border-transparent border-t-white" />;
+  return <span className="h-4 w-4 animate-spin rounded-full border border-transparent border-t-[var(--brand)]" />;
 }
 
 export default function UserMenu() {
@@ -44,7 +44,7 @@ export default function UserMenu() {
 
   if (loading) {
     return (
-      <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-white/70">
+      <div className="inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-xs text-neutral-600 shadow-sm">
         <Spinner />
         <span>Connecting…</span>
       </div>
@@ -56,7 +56,7 @@ export default function UserMenu() {
       <button
         type="button"
         onClick={() => void signInWithGoogle()}
-        className="inline-flex items-center gap-2 rounded-full bg-white text-black px-3.5 py-1.5 text-sm font-medium shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40"
+        className="inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-3.5 py-1.5 text-sm font-semibold text-neutral-800 shadow-sm transition hover:border-neutral-300 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand)]"
       >
         <GoogleIcon className="h-4 w-4" />
         School login
@@ -75,19 +75,19 @@ export default function UserMenu() {
       <button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
-        className="flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-left text-sm text-white/90 transition hover:border-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-500)]"
+        className="flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-left text-sm text-neutral-800 shadow-sm transition hover:border-neutral-300 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand)]"
         aria-haspopup="menu"
         aria-expanded={open}
       >
-        <span className="grid h-7 w-7 place-items-center rounded-full bg-[var(--brand)] text-xs font-semibold uppercase text-white">
+        <span className="grid h-7 w-7 place-items-center rounded-full bg-[var(--brand)] text-xs font-semibold uppercase text-white shadow-sm">
           {initials}
         </span>
         <span className="leading-tight">
-          <span className="block text-xs text-white/60">School access</span>
-          <span className="block max-w-[10rem] truncate font-medium">{user.name}</span>
+          <span className="block text-xs uppercase tracking-wide text-neutral-500">School access</span>
+          <span className="block max-w-[10rem] truncate font-medium text-neutral-900">{user.name}</span>
         </span>
         <svg
-          className={`h-4 w-4 shrink-0 transition ${open ? "rotate-180" : "rotate-0"}`}
+          className={`h-4 w-4 shrink-0 text-neutral-500 transition ${open ? "rotate-180" : "rotate-0"}`}
           viewBox="0 0 20 20"
           fill="none"
           aria-hidden
@@ -99,12 +99,12 @@ export default function UserMenu() {
       {open ? (
         <div
           role="menu"
-          className="absolute right-0 mt-2 w-56 rounded-lg border border-white/10 bg-[#111]/95 p-3 text-sm shadow-xl backdrop-blur"
+          className="absolute right-0 mt-2 w-60 rounded-xl border border-neutral-200 bg-white p-3 text-sm text-neutral-800 shadow-xl ring-1 ring-black/5"
         >
           <div className="mb-3 space-y-1">
-            <p className="text-xs uppercase tracking-wide text-white/50">Google Workspace account</p>
-            <p className="font-medium text-white">{user.name}</p>
-            <p className="text-xs text-white/60">{user.email}</p>
+            <p className="text-xs uppercase tracking-wide text-neutral-500">Google Workspace account</p>
+            <p className="font-medium text-neutral-900">{user.name}</p>
+            <p className="text-xs text-neutral-600">{user.email}</p>
           </div>
           <Link
             href="/students"
@@ -120,7 +120,7 @@ export default function UserMenu() {
               void signOut();
               setOpen(false);
             }}
-            className="mt-2 w-full rounded-md border border-white/10 px-3 py-2 text-white/80 transition hover:bg-white/10"
+            className="mt-2 w-full rounded-md border border-neutral-200 px-3 py-2 text-neutral-600 transition hover:border-neutral-300 hover:bg-neutral-100 hover:text-neutral-900"
             role="menuitem"
           >
             Sign out

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -5,7 +5,7 @@ import React from "react";
 export default function Select({ className = "", ...props }: React.SelectHTMLAttributes<HTMLSelectElement>) {
   return (
     <select
-      className={`border border-white/10 bg-white/5 text-white rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-[var(--brand)] focus:border-[var(--brand)] transition ${className}`}
+      className={`rounded-md border border-white/15 bg-white/95 px-3 py-2 text-sm text-slate-900 shadow-[0_18px_36px_-28px_rgba(15,23,42,0.65)] outline-none transition placeholder:text-slate-400 focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand)] ${className}`}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- refresh the global palette to a crimson, white, and soft grey scheme for a brighter application shell
- rebuild the sticky header with simplified branding, crimson underline accent, and compact profile area
- restyle navigation and user menu dropdowns for high-contrast legibility on light surfaces

## Testing
- pnpm lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4accd7fc832f9c3e5b4f9375fc2c